### PR TITLE
Add icons and basic tabbed UI

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
@@ -4,11 +4,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.Collections
+import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -20,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.NavHost
@@ -45,21 +51,23 @@ class MainActivity : ComponentActivity() {
 }
 
 /** Top-level routes for bottom navigation */
-private enum class RootRoute(val route: String, val label: String) {
-    Explore("explore", "Explore"),
-    Library("library", "Library"),
-    Sources("sources", "Sources"),
-    Settings("settings", "Settings")
+private enum class RootRoute(
+    val route: String,
+    val label: String,
+    val icon: ImageVector
+) {
+    Explore("explore", "Explore", Icons.Outlined.Explore),
+    Library("library", "Library", Icons.Outlined.Collections),
+    Sources("sources", "Sources", Icons.Outlined.Cloud),
+    Settings("settings", "Settings", Icons.Outlined.Settings)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WallBaseApp() {
     val navController = rememberNavController()
-    val currentDestination by navController.currentBackStackEntryAsState()
-        .let { state -> state.value?.destination }.let { destState ->
-            androidx.compose.runtime.rememberUpdatedState(destState)
-        }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -91,8 +99,13 @@ fun WallBaseApp() {
                                 }
                             }
                         },
-                        // Placeholder icon to avoid extra dependencies for now
-                        icon = { Spacer(Modifier.size(24.dp)) },
+                        icon = {
+                            Icon(
+                                imageVector = item.icon,
+                                contentDescription = item.label,
+                                modifier = Modifier.size(24.dp)
+                            )
+                        },
                         label = { Text(item.label) }
                     )
                 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/ExploreScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/ExploreScreen.kt
@@ -1,20 +1,62 @@
 package com.joshiminh.wallbase.ui
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.painterResource
+import com.joshiminh.wallbase.R
+
+private data class ExploreTab(@DrawableRes val icon: Int, val label: String)
 
 @Composable
 fun ExploreScreen() {
-    // Roadmap: Top App Bar Tabs → one per enabled source
-    // Placeholder until you wire real data + TabRow/pager
-    Text(
-        text = "Explore → Sources: Google Photos, Google Drive, Reddit, Local, Websites, Pinterest",
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
-    )
+    val tabs = remember {
+        listOf(
+            ExploreTab(R.drawable.google_photos, "Google Photos"),
+            ExploreTab(R.drawable.google_drive, "Google Drive"),
+            ExploreTab(R.drawable.reddit, "Reddit"),
+            ExploreTab(R.drawable.pinterest, "Pinterest")
+        )
+    }
+    var selectedTab by remember { mutableStateOf(0) }
+
+    Column(Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            tabs.forEachIndexed { index, tab ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { selectedTab = index },
+                    text = { Text(tab.label) },
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = tab.icon),
+                            contentDescription = tab.label
+                        )
+                    }
+                )
+            }
+        }
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "Content for ${tabs[selectedTab].label}",
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
@@ -1,19 +1,43 @@
 package com.joshiminh.wallbase.ui
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun LibraryScreen() {
-    // Roadmap: TabRow with "All Wallpapers" + "Albums"
-    Text(
-        text = "Library Tabs: All Wallpapers, Albums",
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
-    )
+    val tabs = listOf("All Wallpapers", "Albums")
+    var selectedTab by remember { mutableStateOf(0) }
+
+    Column(Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { selectedTab = index },
+                    text = { Text(title) }
+                )
+            }
+        }
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "${tabs[selectedTab]} content", 
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -1,24 +1,31 @@
 package com.joshiminh.wallbase.ui
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun SettingsScreen() {
-    Text(
-        text = """
-            Settings:
-            • Theme: Follow System (auto-sync dark mode already supported)
-            • Wallpapers: Apply via Samsung System Preview (planned)
-            • Backup/Restore
-            • About
-        """.trimIndent(),
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
+    val items = listOf(
+        "Theme: Follow System (auto-sync dark mode)",
+        "Library storage: SQLite only (saved/liked, albums, schedules)",
+        "Wallpapers: Apply via Samsung System Preview (planned: set home/lock, cropping)",
+        "Search wallpapers",
+        "Slide show & scheduled wallpapers",
+        "Backup/Restore",
+        "About"
     )
+    LazyColumn(contentPadding = PaddingValues(16.dp)) {
+        items(items) { item ->
+            ListItem(
+                headlineContent = { Text(item) }
+            )
+            Divider()
+        }
+    }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourcesScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourcesScreen.kt
@@ -1,26 +1,57 @@
 package com.joshiminh.wallbase.ui
 
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.joshiminh.wallbase.R
+
+private data class SourceEntry(@DrawableRes val icon: Int, val title: String, val description: String)
 
 @Composable
 fun SourcesScreen() {
-    Text(
-        text = """
-            Sources:
-            • Google Photos — Login, pick albums
-            • Google Drive — Login, pick folder(s)
-            • Reddit — Add subs, sort/time, filters
-            • Pinterest — (planned)
-            • Websites — Templates or custom rules
-            • Local — Device Photo Picker / SAF
-        """.trimIndent(),
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
+    val sources = listOf(
+        SourceEntry(R.drawable.google_photos, "Google Photos", "Login, pick albums"),
+        SourceEntry(R.drawable.google_drive, "Google Drive", "Login, pick folder(s)"),
+        SourceEntry(R.drawable.reddit, "Reddit", "Add subs, sort/time, filters"),
+        SourceEntry(R.drawable.pinterest, "Pinterest", "(planned)"),
+        SourceEntry(android.R.drawable.ic_menu_search, "Websites", "Templates or custom rules"),
+        SourceEntry(android.R.drawable.ic_menu_gallery, "Local", "Device Photo Picker / SAF")
     )
+
+    LazyColumn(contentPadding = PaddingValues(16.dp)) {
+        items(sources) { source ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Icon(
+                    painter = painterResource(id = source.icon),
+                    contentDescription = source.title,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.size(16.dp))
+                Column {
+                    Text(source.title, style = MaterialTheme.typography.titleMedium)
+                    Text(source.description, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Use generic Android icons in bottom navigation
- Outline upcoming features in Settings screen

## Testing
- `sh gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c0eee728cc8330b06dbb7780c744d7