### PR TITLE
Enable system theme sync and source tab icons

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/ui/ExploreScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/ExploreScreen.kt
@@ -1,20 +1,66 @@
 package com.joshiminh.wallbase.ui
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.material3.Icon
 
 @Composable
-fun ExploreScreen() {
-    // Roadmap: Top App Bar Tabs → one per enabled source
-    // Placeholder until you wire real data + TabRow/pager
-    Text(
-        text = "Explore → Sources: Google Photos, Google Drive, Reddit, Local, Websites, Pinterest",
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
-    )
+fun ExploreScreen(sources: List<Source>) {
+    var selectedTab by remember { mutableStateOf(0) }
+    val enabledSources = sources.filter { it.enabled }
+    if (selectedTab >= enabledSources.size) selectedTab = 0
+
+    Column(Modifier.fillMaxSize()) {
+        if (enabledSources.isNotEmpty()) {
+            ScrollableTabRow(selectedTabIndex = selectedTab) {
+                enabledSources.forEachIndexed { index, source ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(source.title) },
+                        icon = {
+                            Icon(
+                                painter = painterResource(id = source.icon),
+                                contentDescription = source.title,
+                                tint = Color.Unspecified
+                            )
+                        }
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Content for ${enabledSources[selectedTab].title}",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+        } else {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Enable a source to explore wallpapers",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
@@ -1,19 +1,43 @@
 package com.joshiminh.wallbase.ui
 
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun LibraryScreen() {
-    // Roadmap: TabRow with "All Wallpapers" + "Albums"
-    Text(
-        text = "Library Tabs: All Wallpapers, Albums",
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
-    )
+    val tabs = listOf("All Wallpapers", "Albums")
+    var selectedTab by remember { mutableStateOf(0) }
+
+    Column(Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { selectedTab = index },
+                    text = { Text(title) }
+                )
+            }
+        }
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "${tabs[selectedTab]} content", 
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -1,24 +1,57 @@
 package com.joshiminh.wallbase.ui
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun SettingsScreen() {
-    Text(
-        text = """
-            Settings:
-            • Theme: Follow System (auto-sync dark mode already supported)
-            • Wallpapers: Apply via Samsung System Preview (planned)
-            • Backup/Restore
-            • About
-        """.trimIndent(),
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
+fun SettingsScreen(
+    darkTheme: Boolean,
+    followSystem: Boolean,
+    onToggleDarkTheme: (Boolean) -> Unit,
+    onToggleFollowSystem: (Boolean) -> Unit
+) {
+    val items = listOf(
+        "Library storage: SQLite only (saved/liked, albums, schedules)",
+        "Wallpapers: Apply via Samsung System Preview (planned: set home/lock, cropping)",
+        "Search wallpapers",
+        "Slide show & scheduled wallpapers",
+        "Backup/Restore",
+        "About"
     )
+    LazyColumn(contentPadding = PaddingValues(16.dp)) {
+        item {
+            ListItem(
+                headlineContent = { Text("Auto-sync with system dark mode") },
+                trailingContent = {
+                    Switch(
+                        checked = followSystem,
+                        onCheckedChange = onToggleFollowSystem
+                    )
+                }
+            )
+            Divider()
+            ListItem(
+                headlineContent = { Text("Dark mode") },
+                trailingContent = {
+                    Switch(
+                        checked = darkTheme,
+                        onCheckedChange = onToggleDarkTheme,
+                        enabled = !followSystem
+                    )
+                }
+            )
+            Divider()
+        }
+        items(items) { item ->
+            ListItem(headlineContent = { Text(item) })
+            Divider()
+        }
+    }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/Source.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/Source.kt
@@ -1,0 +1,17 @@
+package com.joshiminh.wallbase.ui
+
+import androidx.annotation.DrawableRes
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+class Source(
+    val id: String,
+    @DrawableRes val icon: Int,
+    val title: String,
+    val description: String,
+    enabled: Boolean = false
+) {
+    var enabled by mutableStateOf(enabled)
+}
+

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourcesScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourcesScreen.kt
@@ -1,26 +1,63 @@
 package com.joshiminh.wallbase.ui
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun SourcesScreen() {
-    Text(
-        text = """
-            Sources:
-            • Google Photos — Login, pick albums
-            • Google Drive — Login, pick folder(s)
-            • Reddit — Add subs, sort/time, filters
-            • Pinterest — (planned)
-            • Websites — Templates or custom rules
-            • Local — Device Photo Picker / SAF
-        """.trimIndent(),
-        modifier = Modifier.padding(PaddingValues(16.dp)),
-        style = MaterialTheme.typography.bodyLarge
-    )
+fun SourcesScreen(sources: List<Source>) {
+    LazyColumn(contentPadding = PaddingValues(16.dp)) {
+        items(sources) { source ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Image(
+                        painter = painterResource(id = source.icon),
+                        contentDescription = source.title,
+                        modifier = Modifier.size(40.dp)
+                    )
+                    Spacer(Modifier.width(16.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(source.title, style = MaterialTheme.typography.titleMedium)
+                        Text(source.description, style = MaterialTheme.typography.bodyMedium)
+                    }
+                    Switch(
+                        checked = source.enabled,
+                        onCheckedChange = { source.enabled = it }
+                    )
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Sync dark mode with system setting and allow manual override in Settings
- Show each enabled source's icon in Explore's tab row
- Use built-in Android icons for bottom navigation to avoid missing dependencies

## Testing
- `sh gradlew build` (fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")

------
https://chatgpt.com/codex/tasks/task_e_68c0eee728cc8330b06dbb7780c744d7