### PR TITLE
Implement source toggles and dark mode

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
@@ -23,15 +23,20 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.joshiminh.wallbase.data.Source
 import com.joshiminh.wallbase.theme.WallBaseTheme
 import com.joshiminh.wallbase.ui.ExploreScreen
 import com.joshiminh.wallbase.ui.LibraryScreen
@@ -43,8 +48,23 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            WallBaseTheme {
-                WallBaseApp()
+            var darkTheme by remember { mutableStateOf(false) }
+            val sources = remember {
+                listOf(
+                    Source(R.drawable.google_photos, "Google Photos", "Login, pick albums", true, true),
+                    Source(R.drawable.google_drive, "Google Drive", "Login, pick folder(s)", true, true),
+                    Source(R.drawable.reddit, "Reddit", "Add subs, sort/time, filters", true, true),
+                    Source(R.drawable.pinterest, "Pinterest", "(planned)", true, true),
+                    Source(android.R.drawable.ic_menu_search, "Websites", "Templates or custom rules", false, false),
+                    Source(android.R.drawable.ic_menu_gallery, "Local", "Device Photo Picker / SAF", false, false)
+                ).toMutableStateList()
+            }
+            WallBaseTheme(darkTheme = darkTheme) {
+                WallBaseApp(
+                    sources = sources,
+                    darkTheme = darkTheme,
+                    onToggleDarkTheme = { darkTheme = it }
+                )
             }
         }
     }
@@ -64,7 +84,11 @@ private enum class RootRoute(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WallBaseApp() {
+fun WallBaseApp(
+    sources: SnapshotStateList<Source>,
+    darkTheme: Boolean,
+    onToggleDarkTheme: (Boolean) -> Unit
+) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
@@ -117,10 +141,15 @@ fun WallBaseApp() {
             startDestination = RootRoute.Explore.route,
             modifier = Modifier.padding(innerPadding)
         ) {
-            composable(RootRoute.Explore.route) { ExploreScreen() }
+            composable(RootRoute.Explore.route) { ExploreScreen(sources) }
             composable(RootRoute.Library.route) { LibraryScreen() }
-            composable(RootRoute.Sources.route) { SourcesScreen() }
-            composable(RootRoute.Settings.route) { SettingsScreen() }
+            composable(RootRoute.Sources.route) { SourcesScreen(sources) }
+            composable(RootRoute.Settings.route) {
+                SettingsScreen(
+                    darkTheme = darkTheme,
+                    onToggleDarkTheme = onToggleDarkTheme
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/data/Source.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/Source.kt
@@ -1,0 +1,11 @@
+package com.joshiminh.wallbase.data
+
+import androidx.annotation.DrawableRes
+
+data class Source(
+    @DrawableRes val icon: Int,
+    val title: String,
+    val description: String,
+    val showInExplore: Boolean,
+    val enabled: Boolean
+)

--- a/app/src/main/java/com/joshiminh/wallbase/ui/ExploreScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/ExploreScreen.kt
@@ -1,13 +1,11 @@
 package com.joshiminh.wallbase.ui
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,47 +14,40 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import com.joshiminh.wallbase.R
-
-private data class ExploreTab(@DrawableRes val icon: Int, val label: String)
+import com.joshiminh.wallbase.data.Source
 
 @Composable
-fun ExploreScreen() {
-    val tabs = remember {
-        listOf(
-            ExploreTab(R.drawable.google_photos, "Google Photos"),
-            ExploreTab(R.drawable.google_drive, "Google Drive"),
-            ExploreTab(R.drawable.reddit, "Reddit"),
-            ExploreTab(R.drawable.pinterest, "Pinterest")
-        )
-    }
+fun ExploreScreen(sources: List<Source>) {
+    val tabs = sources.filter { it.enabled && it.showInExplore }
     var selectedTab by remember { mutableStateOf(0) }
 
-    Column(Modifier.fillMaxSize()) {
-        TabRow(selectedTabIndex = selectedTab) {
-            tabs.forEachIndexed { index, tab ->
-                Tab(
-                    selected = selectedTab == index,
-                    onClick = { selectedTab = index },
-                    text = { Text(tab.label) },
-                    icon = {
-                        Icon(
-                            painter = painterResource(id = tab.icon),
-                            contentDescription = tab.label
-                        )
-                    }
-                )
-            }
-        }
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
+    if (tabs.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(
-                text = "Content for ${tabs[selectedTab].label}",
+                text = "No sources enabled",
                 style = MaterialTheme.typography.bodyLarge
             )
+        }
+    } else {
+        Column(Modifier.fillMaxSize()) {
+            ScrollableTabRow(selectedTabIndex = selectedTab) {
+                tabs.forEachIndexed { index, tab ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(tab.title) }
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Content for ${tabs[selectedTab].title}",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -5,14 +5,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun SettingsScreen() {
+fun SettingsScreen(
+    darkTheme: Boolean,
+    onToggleDarkTheme: (Boolean) -> Unit
+) {
     val items = listOf(
-        "Theme: Follow System (auto-sync dark mode)",
         "Library storage: SQLite only (saved/liked, albums, schedules)",
         "Wallpapers: Apply via Samsung System Preview (planned: set home/lock, cropping)",
         "Search wallpapers",
@@ -21,6 +24,15 @@ fun SettingsScreen() {
         "About"
     )
     LazyColumn(contentPadding = PaddingValues(16.dp)) {
+        item {
+            ListItem(
+                headlineContent = { Text("Dark mode") },
+                trailingContent = {
+                    Switch(checked = darkTheme, onCheckedChange = onToggleDarkTheme)
+                }
+            )
+            Divider()
+        }
         items(items) { item ->
             ListItem(
                 headlineContent = { Text(item) }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourcesScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourcesScreen.kt
@@ -1,6 +1,6 @@
 package com.joshiminh.wallbase.ui
 
-import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -9,47 +9,54 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.joshiminh.wallbase.R
-
-private data class SourceEntry(@DrawableRes val icon: Int, val title: String, val description: String)
+import com.joshiminh.wallbase.data.Source
 
 @Composable
-fun SourcesScreen() {
-    val sources = listOf(
-        SourceEntry(R.drawable.google_photos, "Google Photos", "Login, pick albums"),
-        SourceEntry(R.drawable.google_drive, "Google Drive", "Login, pick folder(s)"),
-        SourceEntry(R.drawable.reddit, "Reddit", "Add subs, sort/time, filters"),
-        SourceEntry(R.drawable.pinterest, "Pinterest", "(planned)"),
-        SourceEntry(android.R.drawable.ic_menu_search, "Websites", "Templates or custom rules"),
-        SourceEntry(android.R.drawable.ic_menu_gallery, "Local", "Device Photo Picker / SAF")
-    )
-
+fun SourcesScreen(sources: SnapshotStateList<Source>) {
     LazyColumn(contentPadding = PaddingValues(16.dp)) {
-        items(sources) { source ->
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+        itemsIndexed(sources) { index, source ->
+            Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 8.dp)
+                    .padding(vertical = 8.dp),
+                shape = RoundedCornerShape(8.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
             ) {
-                Icon(
-                    painter = painterResource(id = source.icon),
-                    contentDescription = source.title,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(Modifier.size(16.dp))
-                Column {
-                    Text(source.title, style = MaterialTheme.typography.titleMedium)
-                    Text(source.description, style = MaterialTheme.typography.bodyMedium)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Image(
+                        painter = painterResource(id = source.icon),
+                        contentDescription = source.title,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(Modifier.size(16.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(source.title, style = MaterialTheme.typography.titleMedium)
+                        Text(source.description, style = MaterialTheme.typography.bodyMedium)
+                    }
+                    Switch(
+                        checked = source.enabled,
+                        onCheckedChange = { checked ->
+                            sources[index] = source.copy(enabled = checked)
+                        }
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Allow unlimited-width tabs in Explore and only show enabled sources
- Add card-based Sources screen with switches and colored icons
- Introduce dark mode switch in Settings and wire theme state

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c13318ef808330858e6e6eaa9a214f