### PR TITLE
Fix Compose pull refresh dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.foundation)
-    implementation("androidx.compose.material:material-pull-refresh")
+    implementation(libs.androidx.compose.material.pullrefresh)
 
     // Tooling & Testing for Compose
     debugImplementation(libs.androidx.ui.tooling)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ androidx-material3 = { module = "androidx.compose.material3:material3" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-compose-material-pullrefresh = { module = "androidx.compose.material:pull-refresh" }
 
 # DocumentFile (SAF helpers)
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }


### PR DESCRIPTION
## Summary
- switch the pull refresh dependency to the version catalog alias
- add the Compose pull refresh artifact to the shared version catalog

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cceb6b00148330ac2d9d75d4aefb4d