### PR TITLE
Add vendor-specific wallpaper handling and database backups

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/data/local/DatabaseBackupManager.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/local/DatabaseBackupManager.kt
@@ -1,0 +1,92 @@
+package com.joshiminh.wallbase.data.local
+
+import android.content.Context
+import android.net.Uri
+import androidx.sqlite.db.SupportSQLiteDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+class DatabaseBackupManager(
+    private val context: Context,
+    private val database: WallBaseDatabase = WallBaseDatabase.getInstance(context)
+) {
+
+    suspend fun exportBackup(destination: Uri): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val dbFile = context.getDatabasePath(DATABASE_NAME)
+            if (!dbFile.exists()) {
+                error("Database file not found")
+            }
+
+            // Flush the write-ahead log so the on-disk file contains the latest data.
+            val sqliteDb = database.openHelper.writableDatabase
+            sqliteDb.query("PRAGMA wal_checkpoint(FULL)").use { }
+
+            context.contentResolver.openOutputStream(destination)?.use { output ->
+                dbFile.inputStream().use { input ->
+                    input.copyTo(output)
+                }
+            } ?: error("Unable to open destination for backup")
+        }
+    }
+
+    suspend fun importBackup(source: Uri): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val tempFile = File.createTempFile("wallbase_backup_", ".db", context.cacheDir)
+
+            context.contentResolver.openInputStream(source)?.use { input ->
+                FileOutputStream(tempFile).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: error("Unable to open backup source")
+
+            val sqliteDb = database.openHelper.writableDatabase
+            sqliteDb.execSQL("PRAGMA foreign_keys=OFF")
+            sqliteDb.beginTransaction()
+            try {
+                sqliteDb.execSQL("ATTACH DATABASE ? AS backup", arrayOf(tempFile.absolutePath))
+                try {
+                    DATA_TABLES.forEach { table ->
+                        sqliteDb.execSQL("DELETE FROM $table")
+                        if (sqliteDb.hasTable("backup", table)) {
+                            sqliteDb.execSQL("INSERT INTO $table SELECT * FROM backup.$table")
+                        }
+                    }
+
+                    sqliteDb.execSQL("DELETE FROM sqlite_sequence")
+                    if (sqliteDb.hasTable("backup", "sqlite_sequence")) {
+                        sqliteDb.execSQL("INSERT INTO sqlite_sequence SELECT * FROM backup.sqlite_sequence")
+                    }
+
+                    sqliteDb.setTransactionSuccessful()
+                } finally {
+                    runCatching { sqliteDb.execSQL("DETACH DATABASE backup") }
+                }
+            } finally {
+                sqliteDb.endTransaction()
+                sqliteDb.execSQL("PRAGMA foreign_keys=ON")
+                tempFile.delete()
+            }
+        }
+    }
+
+    private fun SupportSQLiteDatabase.hasTable(databaseName: String, tableName: String): Boolean {
+        val cursor = query(
+            "SELECT name FROM ${databaseName}.sqlite_master WHERE type='table' AND name=?",
+            arrayOf(tableName)
+        )
+        cursor.use { return it.moveToFirst() }
+    }
+
+    companion object {
+        private const val DATABASE_NAME = "wallbase.db"
+        private val DATA_TABLES = listOf(
+            "sources",
+            "wallpapers",
+            "albums",
+            "album_wallpaper_cross_ref"
+        )
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/data/local/dao/AlbumDao.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/local/dao/AlbumDao.kt
@@ -19,7 +19,7 @@ interface AlbumDao {
     suspend fun insertAlbums(albums: List<AlbumEntity>): List<Long>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insertCrossRefs(refs: List<AlbumWallpaperCrossRef>)
+    suspend fun insertCrossRefs(refs: List<AlbumWallpaperCrossRef>): List<Long>
 
     @Transaction
     @Query("SELECT * FROM albums ORDER BY sort_order, title")

--- a/app/src/main/java/com/joshiminh/wallbase/data/local/dao/WallpaperDao.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/local/dao/WallpaperDao.kt
@@ -27,6 +27,12 @@ interface WallpaperDao {
     @Query("SELECT EXISTS(SELECT 1 FROM wallpapers WHERE source_key = :sourceKey AND image_url = :imageUrl)")
     suspend fun existsByImageUrl(sourceKey: String, imageUrl: String): Boolean
 
+    @Query("SELECT wallpaper_id FROM wallpapers WHERE source_key = :sourceKey AND remote_id = :remoteId LIMIT 1")
+    suspend fun findIdByRemoteId(sourceKey: String, remoteId: String): Long?
+
+    @Query("SELECT wallpaper_id FROM wallpapers WHERE source_key = :sourceKey AND image_url = :imageUrl LIMIT 1")
+    suspend fun findIdByImageUrl(sourceKey: String, imageUrl: String): Long?
+
     @Query("DELETE FROM wallpapers WHERE source_key = :sourceKey AND remote_id = :remoteId")
     suspend fun deleteBySourceKeyAndRemoteId(sourceKey: String, remoteId: String): Int
 

--- a/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/WallpaperItem.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/WallpaperItem.kt
@@ -13,5 +13,26 @@ data class WallpaperItem(
     val imageUrl: String,
     val sourceUrl: String,
     val sourceName: String? = null,
-    val sourceKey: String? = null
-) : Parcelable
+    val sourceKey: String? = null,
+    val width: Int? = null,
+    val height: Int? = null
+) : Parcelable {
+
+    val aspectRatio: Float?
+        get() {
+            val w = width?.takeIf { it > 0 }?.toFloat() ?: return null
+            val h = height?.takeIf { it > 0 }?.toFloat() ?: return null
+            if (h == 0f) return null
+            return w / h
+        }
+
+    fun libraryKey(): String? {
+        val key = sourceKey ?: return null
+        val normalizedId = if (id.startsWith("$key:")) {
+            id.removePrefix("$key:")
+        } else {
+            id
+        }
+        return "$key:$normalizedId"
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/WallpaperRepository.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/WallpaperRepository.kt
@@ -89,11 +89,14 @@ class WallpaperRepository(
         return data?.children.orEmpty().mapNotNull { child ->
             val post = child.data ?: return@mapNotNull null
             val imageUrl = post.resolveImageUrl() ?: return@mapNotNull null
+            val dimensions = post.preview?.images.orEmpty().firstOrNull()?.source
             WallpaperItem(
                 id = post.id,
                 title = post.title,
                 imageUrl = imageUrl,
-                sourceUrl = post.permalink?.let { "https://www.reddit.com$it" } ?: imageUrl
+                sourceUrl = post.permalink?.let { "https://www.reddit.com$it" } ?: imageUrl,
+                width = dimensions?.width,
+                height = dimensions?.height
             )
         }
     }

--- a/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/platform/PixelWallpaperHandler.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/platform/PixelWallpaperHandler.kt
@@ -1,0 +1,36 @@
+package com.joshiminh.wallbase.data.wallpapers.platform
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import com.joshiminh.wallbase.data.wallpapers.WallpaperTarget
+
+internal object PixelWallpaperHandler : WallpaperPlatformHandler {
+
+    override fun isEligible(context: Context): Boolean {
+        val manufacturer = Build.MANUFACTURER?.lowercase()
+        val brand = Build.BRAND?.lowercase()
+        val model = Build.MODEL?.lowercase()
+        return manufacturer == "google" || brand == "google" || model?.contains("pixel") == true
+    }
+
+    override fun buildPreviewIntent(context: Context, uri: Uri): Intent {
+        return Intent(Intent.ACTION_ATTACH_DATA).apply {
+            addCategory(Intent.CATEGORY_DEFAULT)
+            setDataAndType(uri, "image/*")
+            putExtra("mimeType", "image/*")
+            putExtra("from_wallpaper", true)
+        }
+    }
+
+    override fun applyWallpaper(
+        context: Context,
+        bitmap: Bitmap,
+        target: WallpaperTarget
+    ): Boolean {
+        // Pixels defer to the platform wallpaper manager for application.
+        return false
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/platform/SamsungWallpaperHandler.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/platform/SamsungWallpaperHandler.kt
@@ -1,0 +1,57 @@
+package com.joshiminh.wallbase.data.wallpapers.platform
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import com.joshiminh.wallbase.data.wallpapers.WallpaperTarget
+
+internal object SamsungWallpaperHandler : WallpaperPlatformHandler {
+
+    override fun isEligible(context: Context): Boolean {
+        return Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+    }
+
+    override fun buildPreviewIntent(context: Context, uri: Uri): Intent {
+        return Intent(Intent.ACTION_ATTACH_DATA).apply {
+            addCategory(Intent.CATEGORY_DEFAULT)
+            setDataAndType(uri, "image/*")
+            putExtra("mimeType", "image/*")
+            putExtra("from_wallpaper", true)
+        }
+    }
+
+    @SuppressLint("PrivateApi", "SoonBlockedPrivateApi", "DiscouragedPrivateApi")
+    override fun applyWallpaper(
+        context: Context,
+        bitmap: Bitmap,
+        target: WallpaperTarget
+    ): Boolean {
+        if (!isEligible(context)) return false
+
+        return runCatching {
+            val clazz = Class.forName("com.samsung.android.wallpaper.SemWallpaperManager")
+            val getInstance = clazz.getMethod("getInstance", Context::class.java)
+            val instance = getInstance.invoke(null, context)
+            val homeFlag = clazz.getField("FLAG_HOME_SCREEN").getInt(null)
+            val lockFlag = clazz.getField("FLAG_LOCK_SCREEN").getInt(null)
+            val setBitmap = clazz.getMethod(
+                "setBitmap",
+                Bitmap::class.java,
+                Int::class.javaPrimitiveType
+            )
+
+            when (target) {
+                WallpaperTarget.HOME -> setBitmap.invoke(instance, bitmap, homeFlag)
+                WallpaperTarget.LOCK -> setBitmap.invoke(instance, bitmap, lockFlag)
+                WallpaperTarget.BOTH -> {
+                    setBitmap.invoke(instance, bitmap, homeFlag)
+                    setBitmap.invoke(instance, bitmap, lockFlag)
+                }
+            }
+            true
+        }.getOrElse { false }
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/platform/WallpaperPlatformHandler.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/wallpapers/platform/WallpaperPlatformHandler.kt
@@ -1,0 +1,33 @@
+package com.joshiminh.wallbase.data.wallpapers.platform
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import com.joshiminh.wallbase.data.wallpapers.WallpaperTarget
+
+/**
+ * Platform-specific hooks that allow devices to provide their own wallpaper
+ * preview or application logic. Implementations should return `false` from
+ * [applyWallpaper] when the request needs to be forwarded to the default
+ * [android.app.WallpaperManager].
+ */
+internal interface WallpaperPlatformHandler {
+
+    /**
+     * @return `true` when the handler should be used on the current device.
+     */
+    fun isEligible(context: Context): Boolean
+
+    /**
+     * Optionally creates a platform preview intent for [uri]. Returning `null`
+     * will fall back to the default preview flow.
+     */
+    fun buildPreviewIntent(context: Context, uri: Uri): Intent?
+
+    /**
+     * Applies the [bitmap] to the requested [target]. Returns `true` if the
+     * platform consumed the request, or `false` to let the default manager run.
+     */
+    fun applyWallpaper(context: Context, bitmap: Bitmap, target: WallpaperTarget): Boolean
+}

--- a/app/src/main/java/com/joshiminh/wallbase/network/RedditModels.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/network/RedditModels.kt
@@ -32,7 +32,9 @@ data class RedditPreviewImage(
 )
 
 data class RedditPreviewSource(
-    val url: String? = null
+    val url: String? = null,
+    val width: Int? = null,
+    val height: Int? = null
 )
 
 data class RedditSubredditListingResponse(

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -2,19 +2,29 @@ package com.joshiminh.wallbase.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.joshiminh.wallbase.R
@@ -22,61 +32,198 @@ import com.joshiminh.wallbase.R
 @Composable
 fun SettingsScreen(
     darkTheme: Boolean,
-    onToggleDarkTheme: (Boolean) -> Unit
+    uiState: SettingsViewModel.SettingsUiState,
+    onToggleDarkTheme: (Boolean) -> Unit,
+    onExportBackup: () -> Unit,
+    onImportBackup: () -> Unit,
+    onMessageShown: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 24.dp, vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        Text(
-            text = stringResource(id = R.string.settings_title),
-            style = MaterialTheme.typography.headlineSmall
-        )
+    val snackbarHostState = remember { SnackbarHostState() }
 
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    LaunchedEffect(uiState.message) {
+        val message = uiState.message ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        onMessageShown()
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
             Text(
-                text = stringResource(id = R.string.settings_appearance_header),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = stringResource(id = R.string.settings_title),
+                style = MaterialTheme.typography.headlineSmall
             )
 
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(20.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+            SettingsSection(spacing = 12.dp) {
+                Text(
+                    text = stringResource(id = R.string.settings_appearance_header),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
+
+                SettingsCard {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp, vertical = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
-                            text = stringResource(id = R.string.settings_dark_mode_title),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = stringResource(id = R.string.settings_dark_mode_description),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.settings_dark_mode_title),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                text = stringResource(id = R.string.settings_dark_mode_description),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        Switch(
+                            checked = darkTheme,
+                            onCheckedChange = onToggleDarkTheme
                         )
                     }
+                }
+            }
 
-                    Switch(
-                        checked = darkTheme,
-                        onCheckedChange = onToggleDarkTheme
-                    )
+            SettingsSection(spacing = 12.dp) {
+                Text(
+                    text = stringResource(id = R.string.settings_backup_header),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                SettingsCard {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp, vertical = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.settings_backup_export_title),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                text = stringResource(id = R.string.settings_backup_export_description),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        SettingsActionButton(
+                            text = if (uiState.isBackingUp) {
+                                stringResource(id = R.string.settings_backup_export_in_progress)
+                            } else {
+                                stringResource(id = R.string.settings_backup_export_action)
+                            },
+                            enabled = !uiState.isBackingUp && !uiState.isRestoring,
+                            showProgress = uiState.isBackingUp,
+                            onClick = onExportBackup
+                        )
+                    }
+                }
+
+                SettingsCard {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp, vertical = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.settings_backup_import_title),
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Text(
+                                text = stringResource(id = R.string.settings_backup_import_description),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        SettingsActionButton(
+                            text = if (uiState.isRestoring) {
+                                stringResource(id = R.string.settings_backup_import_in_progress)
+                            } else {
+                                stringResource(id = R.string.settings_backup_import_action)
+                            },
+                            enabled = !uiState.isRestoring && !uiState.isBackingUp,
+                            showProgress = uiState.isRestoring,
+                            onClick = onImportBackup
+                        )
+                    }
                 }
             }
         }
     }
 }
+
+@Composable
+private fun SettingsSection(
+    spacing: Dp,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(spacing), content = content)
+}
+
+@Composable
+private fun SettingsCard(content: @Composable () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        content = content
+    )
+}
+
+@Composable
+private fun SettingsActionButton(
+    text: String,
+    enabled: Boolean,
+    showProgress: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled
+    ) {
+        if (showProgress) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(18.dp)
+                    .padding(end = 12.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+        }
+        Text(text = text)
+    }
+}
+

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsViewModel.kt
@@ -1,0 +1,90 @@
+package com.joshiminh.wallbase.ui
+
+import android.app.Application
+import android.net.Uri
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.joshiminh.wallbase.R
+import com.joshiminh.wallbase.data.local.DatabaseBackupManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class SettingsViewModel(
+    application: Application,
+    private val backupManager: DatabaseBackupManager = DatabaseBackupManager(application.applicationContext)
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    fun exportBackup(destination: Uri) {
+        if (_uiState.value.isBackingUp) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isBackingUp = true, message = null) }
+            val result = backupManager.exportBackup(destination)
+            val message = result.fold(
+                onSuccess = {
+                    getApplication<Application>().getString(R.string.settings_backup_export_success)
+                },
+                onFailure = { error ->
+                    val detail = error.localizedMessage
+                    val app = getApplication<Application>()
+                    if (detail.isNullOrBlank()) {
+                        app.getString(R.string.settings_backup_export_failure)
+                    } else {
+                        app.getString(R.string.settings_backup_export_failure_with_reason, detail)
+                    }
+                }
+            )
+            _uiState.update { it.copy(isBackingUp = false, message = message) }
+        }
+    }
+
+    fun importBackup(source: Uri) {
+        if (_uiState.value.isRestoring) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRestoring = true, message = null) }
+            val result = backupManager.importBackup(source)
+            val message = result.fold(
+                onSuccess = {
+                    getApplication<Application>().getString(R.string.settings_backup_import_success)
+                },
+                onFailure = { error ->
+                    val detail = error.localizedMessage
+                    val app = getApplication<Application>()
+                    if (detail.isNullOrBlank()) {
+                        app.getString(R.string.settings_backup_import_failure)
+                    } else {
+                        app.getString(R.string.settings_backup_import_failure_with_reason, detail)
+                    }
+                }
+            )
+            _uiState.update { it.copy(isRestoring = false, message = message) }
+        }
+    }
+
+    fun consumeMessage() {
+        _uiState.update { it.copy(message = null) }
+    }
+
+    data class SettingsUiState(
+        val isBackingUp: Boolean = false,
+        val isRestoring: Boolean = false,
+        val message: String? = null
+    )
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application
+                SettingsViewModel(application)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseScreen.kt
@@ -1,5 +1,6 @@
 package com.joshiminh.wallbase.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,13 +10,28 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.LibraryAdd
+import androidx.compose.material.icons.outlined.PlaylistAdd
+import androidx.compose.material.icons.outlined.TaskAlt
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -23,12 +39,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.joshiminh.wallbase.R
+import com.joshiminh.wallbase.data.library.AlbumItem
 import com.joshiminh.wallbase.data.wallpapers.WallpaperItem
 import com.joshiminh.wallbase.ui.components.WallpaperGrid
 
@@ -40,6 +63,7 @@ fun SourceBrowseRoute(
     viewModel: SourceBrowseViewModel = viewModel(factory = SourceBrowseViewModel.provideFactory(sourceKey))
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(uiState.source?.title) {
         onTitleChange(uiState.source?.title)
@@ -48,13 +72,36 @@ fun SourceBrowseRoute(
         onDispose { onTitleChange(null) }
     }
 
+    LaunchedEffect(uiState.message) {
+        val message = uiState.message ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message)
+        viewModel.consumeMessage()
+    }
+
+    val onCardClick: (WallpaperItem) -> Unit = { wallpaper ->
+        if (uiState.isSelectionMode) {
+            viewModel.toggleSelection(wallpaper)
+        } else {
+            onWallpaperSelected(wallpaper)
+        }
+    }
+
+    val onCardLongPress: (WallpaperItem) -> Unit = { wallpaper ->
+        viewModel.beginSelection(wallpaper)
+    }
+
     SourceBrowseScreen(
         state = uiState,
+        snackbarHostState = snackbarHostState,
         onQueryChange = viewModel::updateQuery,
         onClearQuery = viewModel::clearQuery,
         onSearch = viewModel::search,
         onRefresh = viewModel::refresh,
-        onWallpaperSelected = onWallpaperSelected
+        onWallpaperClick = onCardClick,
+        onWallpaperLongPress = onCardLongPress,
+        onClearSelection = viewModel::clearSelection,
+        onAddSelectionToLibrary = viewModel::addSelectedToLibrary,
+        onAddSelectionToAlbum = viewModel::addSelectedToAlbum
     )
 }
 
@@ -62,11 +109,16 @@ fun SourceBrowseRoute(
 @Composable
 private fun SourceBrowseScreen(
     state: SourceBrowseViewModel.SourceBrowseUiState,
+    snackbarHostState: SnackbarHostState,
     onQueryChange: (String) -> Unit,
     onClearQuery: () -> Unit,
     onSearch: () -> Unit,
     onRefresh: () -> Unit,
-    onWallpaperSelected: (WallpaperItem) -> Unit
+    onWallpaperClick: (WallpaperItem) -> Unit,
+    onWallpaperLongPress: (WallpaperItem) -> Unit,
+    onClearSelection: () -> Unit,
+    onAddSelectionToLibrary: () -> Unit,
+    onAddSelectionToAlbum: (Long) -> Unit
 ) {
     val source = state.source
     if (source == null) {
@@ -79,93 +131,131 @@ private fun SourceBrowseScreen(
         return
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-    ) {
-        if (source.description.isNotBlank()) {
-            Text(source.description, style = MaterialTheme.typography.bodyMedium)
-            Spacer(modifier = Modifier.height(12.dp))
-        }
-        OutlinedTextField(
-            value = state.query,
-            onValueChange = onQueryChange,
-            label = { Text("Search this source") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(onSearch = { onSearch() })
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        RowActions(
-            query = state.query,
-            onSearch = onSearch,
-            onClearQuery = onClearQuery
-        )
-        state.errorMessage?.takeIf { state.wallpapers.isEmpty() }?.let { message ->
-            Text(
-                text = message,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(top = 8.dp)
-            )
-        }
-        Spacer(modifier = Modifier.height(12.dp))
+    var showAlbumPicker by rememberSaveable { mutableStateOf(false) }
 
-        // Pull-to-refresh container (Material3)
-        PullToRefreshBox(
-            isRefreshing = state.isRefreshing,
-            onRefresh = onRefresh,
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+    ) { innerPadding ->
+        Column(
             modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
-            // Content inside must be scrollable to enable the gesture.
-            when {
-                state.isLoading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
-                    }
-                }
-
-                state.wallpapers.isEmpty() -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (state.errorMessage != null) {
-                            ErrorMessage(message = state.errorMessage, onRetry = onRefresh)
-                        } else {
-                            Text(
-                                text = "No wallpapers found.",
-                                style = MaterialTheme.typography.bodyLarge
-                            )
+            AnimatedVisibility(visible = state.isSelectionMode) {
+                SelectionBar(
+                    count = state.selectedIds.size,
+                    enabled = !state.isActionInProgress,
+                    onClear = onClearSelection,
+                    onAddToLibrary = onAddSelectionToLibrary,
+                    onAddToAlbum = {
+                        if (!state.isActionInProgress) {
+                            showAlbumPicker = true
                         }
                     }
-                }
+                )
+            }
 
-                else -> {
-                    WallpaperGrid(
-                        wallpapers = state.wallpapers,
-                        onWallpaperSelected = onWallpaperSelected,
-                        modifier = Modifier.fillMaxSize()
-                    )
+            if (state.isSelectionMode) {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            if (source.description.isNotBlank()) {
+                Text(source.description, style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            OutlinedTextField(
+                value = state.query,
+                onValueChange = onQueryChange,
+                label = { Text(stringResource(id = R.string.search_in_source)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onSearch() })
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            RowActions(
+                query = state.query,
+                onSearch = onSearch,
+                onClearQuery = onClearQuery
+            )
+            state.errorMessage?.takeIf { state.wallpapers.isEmpty() }?.let { message ->
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                when {
+                    state.isLoading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+
+                    state.wallpapers.isEmpty() -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (state.errorMessage != null) {
+                                ErrorMessage(message = state.errorMessage, onRetry = onRefresh)
+                            } else {
+                                Text(
+                                    text = stringResource(id = R.string.no_wallpapers_found),
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                        }
+                    }
+
+                    else -> {
+                        WallpaperGrid(
+                            wallpapers = state.wallpapers,
+                            onWallpaperSelected = onWallpaperClick,
+                            onLongPress = onWallpaperLongPress,
+                            selectedIds = state.selectedIds,
+                            selectionMode = state.isSelectionMode,
+                            savedWallpaperKeys = state.savedWallpaperKeys,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
                 }
             }
-        }
 
-        state.errorMessage?.takeIf { state.wallpapers.isNotEmpty() }?.let { message ->
-            Text(
-                text = message,
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(top = 8.dp)
-            )
+            state.errorMessage?.takeIf { state.wallpapers.isNotEmpty() }?.let { message ->
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
         }
+    }
+
+    if (showAlbumPicker) {
+        AlbumPickerDialog(
+            albums = state.albums,
+            onAlbumSelected = { album ->
+                onAddSelectionToAlbum(album.id)
+                showAlbumPicker = false
+            },
+            onDismiss = { showAlbumPicker = false }
+        )
     }
 }
 
@@ -190,6 +280,112 @@ private fun RowActions(
             }
         }
     }
+}
+
+@Composable
+private fun SelectionBar(
+    count: Int,
+    enabled: Boolean,
+    onClear: () -> Unit,
+    onAddToLibrary: () -> Unit,
+    onAddToAlbum: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        tonalElevation = 4.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            IconButton(onClick = onClear) {
+                Icon(
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = stringResource(id = R.string.cancel)
+                )
+            }
+            Text(
+                text = stringResource(id = R.string.selection_count, count),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            FilledTonalButton(
+                onClick = onAddToLibrary,
+                enabled = enabled
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.LibraryAdd,
+                    contentDescription = null
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(id = R.string.selection_save_to_library))
+            }
+            FilledTonalButton(
+                onClick = onAddToAlbum,
+                enabled = enabled
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.PlaylistAdd,
+                    contentDescription = null
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(id = R.string.selection_add_to_album))
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumPickerDialog(
+    albums: List<AlbumItem>,
+    onAlbumSelected: (AlbumItem) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.select_album_title)) },
+        text = {
+            if (albums.isEmpty()) {
+                Text(text = stringResource(id = R.string.selection_no_albums))
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    albums.forEach { album ->
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(12.dp),
+                            tonalElevation = 1.dp,
+                            onClick = { onAlbumSelected(album) }
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                            ) {
+                                Text(
+                                    text = album.title,
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.album_wallpaper_count,
+                                        album.wallpaperCount
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(id = R.string.cancel))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseViewModel.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.joshiminh.wallbase.data.library.AlbumItem
+import com.joshiminh.wallbase.data.library.LibraryRepository
 import com.joshiminh.wallbase.data.source.Source
 import com.joshiminh.wallbase.data.source.SourceRepository
 import com.joshiminh.wallbase.data.wallpapers.WallpaperItem
@@ -20,7 +22,8 @@ import kotlinx.coroutines.launch
 class SourceBrowseViewModel(
     private val sourceKey: String,
     private val sourceRepository: SourceRepository,
-    private val wallpaperRepository: WallpaperRepository
+    private val wallpaperRepository: WallpaperRepository,
+    private val libraryRepository: LibraryRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SourceBrowseUiState())
@@ -53,6 +56,23 @@ class SourceBrowseViewModel(
                     _uiState.value.wallpapers.isEmpty()
                 ) {
                     loadWallpapers(source, query = currentQuery, showLoading = true)
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            libraryRepository.observeSavedWallpapers().collectLatest { saved ->
+                val keys = saved.mapNotNull { it.libraryKey() }.toSet()
+                _uiState.update { state ->
+                    if (state.savedWallpaperKeys == keys) state else state.copy(savedWallpaperKeys = keys)
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            libraryRepository.observeAlbums().collectLatest { albums ->
+                _uiState.update { state ->
+                    if (state.albums == albums) state else state.copy(albums = albums)
                 }
             }
         }
@@ -98,12 +118,16 @@ class SourceBrowseViewModel(
             val result = runCatching { wallpaperRepository.fetchWallpapersFor(source, query) }
             result.fold(
                 onSuccess = { wallpapers ->
-                    _uiState.update {
-                        it.copy(
+                    _uiState.update { state ->
+                        val availableIds = wallpapers.mapTo(hashSetOf()) { it.id }
+                        val retainedSelection = state.selectedIds.filterTo(hashSetOf()) { it in availableIds }
+                        state.copy(
                             wallpapers = wallpapers,
                             isLoading = false,
                             isRefreshing = false,
-                            errorMessage = null
+                            errorMessage = null,
+                            selectedIds = retainedSelection,
+                            isSelectionMode = retainedSelection.isNotEmpty()
                         )
                     }
                 },
@@ -122,13 +146,145 @@ class SourceBrowseViewModel(
         }
     }
 
+    fun beginSelection(wallpaper: WallpaperItem) {
+        modifySelection { it.add(wallpaper.id) }
+    }
+
+    fun toggleSelection(wallpaper: WallpaperItem) {
+        modifySelection {
+            if (!it.add(wallpaper.id)) {
+                it.remove(wallpaper.id)
+            }
+        }
+    }
+
+    fun clearSelection() {
+        _uiState.update { it.copy(selectedIds = emptySet(), isSelectionMode = false) }
+    }
+
+    fun addSelectedToLibrary() {
+        val current = selectedWallpapers()
+        if (current.isEmpty() || _uiState.value.isActionInProgress) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInProgress = true) }
+            val result = runCatching { libraryRepository.addWallpapersToLibrary(current) }
+            _uiState.update { state ->
+                val (message, clearSelection) = result.fold(
+                    onSuccess = { outcome ->
+                        val message = when {
+                            outcome.added > 0 && outcome.skipped > 0 ->
+                                "Saved ${outcome.added} wallpapers (skipped ${outcome.skipped} already saved)"
+
+                            outcome.added > 0 -> "Saved ${outcome.added} wallpapers to your library"
+
+                            else -> "All selected wallpapers are already in your library"
+                        }
+                        message to true
+                    },
+                    onFailure = { error ->
+                        val message = error.localizedMessage?.takeIf { it.isNotBlank() }
+                            ?: "Unable to save wallpapers"
+                        message to false
+                    }
+                )
+                val updatedSelection = if (clearSelection) emptySet() else state.selectedIds
+                state.copy(
+                    isActionInProgress = false,
+                    message = message,
+                    selectedIds = updatedSelection,
+                    isSelectionMode = updatedSelection.isNotEmpty()
+                )
+            }
+        }
+    }
+
+    fun addSelectedToAlbum(albumId: Long) {
+        val albums = _uiState.value.albums
+        if (albums.none { it.id == albumId }) {
+            setMessage("Album not available")
+            return
+        }
+        val current = selectedWallpapers()
+        if (current.isEmpty() || _uiState.value.isActionInProgress) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInProgress = true) }
+            val result = runCatching { libraryRepository.addWallpapersToAlbum(albumId, current) }
+            _uiState.update { state ->
+                val (message, clearSelection) = result.fold(
+                    onSuccess = { outcome ->
+                        val message = when {
+                            outcome.addedToAlbum > 0 && (outcome.alreadyPresent > 0 || outcome.skipped > 0) ->
+                                "Added ${outcome.addedToAlbum} wallpapers (skipped ${outcome.alreadyPresent + outcome.skipped} others)"
+
+                            outcome.addedToAlbum > 0 -> "Added ${outcome.addedToAlbum} wallpapers to the album"
+
+                            outcome.alreadyPresent > 0 && outcome.skipped == 0 ->
+                                "All selected wallpapers are already in this album"
+
+                            outcome.skipped > 0 -> "Unable to add ${outcome.skipped} wallpapers to the album"
+
+                            else -> "All selected wallpapers are already in this album"
+                        }
+                        message to true
+                    },
+                    onFailure = { error ->
+                        val message = error.localizedMessage?.takeIf { it.isNotBlank() }
+                            ?: "Unable to update album"
+                        message to false
+                    }
+                )
+                val updatedSelection = if (clearSelection) emptySet() else state.selectedIds
+                state.copy(
+                    isActionInProgress = false,
+                    message = message,
+                    selectedIds = updatedSelection,
+                    isSelectionMode = updatedSelection.isNotEmpty()
+                )
+            }
+        }
+    }
+
+    fun consumeMessage() {
+        _uiState.update { it.copy(message = null) }
+    }
+
+    private fun selectedWallpapers(): List<WallpaperItem> {
+        val current = _uiState.value
+        if (current.selectedIds.isEmpty()) return emptyList()
+        val byId = current.wallpapers.associateBy { it.id }
+        return current.selectedIds.mapNotNull(byId::get)
+    }
+
+    private fun modifySelection(block: (MutableSet<String>) -> Unit) {
+        _uiState.update { state ->
+            val updated = state.selectedIds.toMutableSet()
+            block(updated)
+            state.copy(
+                selectedIds = updated,
+                isSelectionMode = updated.isNotEmpty()
+            )
+        }
+    }
+
+    private fun setMessage(message: String) {
+        _uiState.update { it.copy(message = message) }
+    }
+
     data class SourceBrowseUiState(
         val source: Source? = null,
         val query: String = "",
         val wallpapers: List<WallpaperItem> = emptyList(),
         val isLoading: Boolean = true,
         val isRefreshing: Boolean = false,
-        val errorMessage: String? = null
+        val errorMessage: String? = null,
+        val savedWallpaperKeys: Set<String> = emptySet(),
+        val isSelectionMode: Boolean = false,
+        val selectedIds: Set<String> = emptySet(),
+        val isActionInProgress: Boolean = false,
+        val message: String? = null,
+        val albums: List<AlbumItem> = emptyList()
     )
 
     companion object {
@@ -137,7 +293,8 @@ class SourceBrowseViewModel(
                 SourceBrowseViewModel(
                     sourceKey = sourceKey,
                     sourceRepository = ServiceLocator.sourceRepository,
-                    wallpaperRepository = ServiceLocator.wallpaperRepository
+                    wallpaperRepository = ServiceLocator.wallpaperRepository,
+                    libraryRepository = ServiceLocator.libraryRepository
                 )
             }
         }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/WallpaperGrid.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/WallpaperGrid.kt
@@ -1,7 +1,8 @@
 package com.joshiminh.wallbase.ui.components
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,13 +12,19 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.outlined.TaskAlt
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,47 +33,70 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.joshiminh.wallbase.R
 import com.joshiminh.wallbase.data.wallpapers.WallpaperItem
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WallpaperGrid(
     wallpapers: List<WallpaperItem>,
     onWallpaperSelected: (WallpaperItem) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onLongPress: ((WallpaperItem) -> Unit)? = null,
+    selectedIds: Set<String> = emptySet(),
+    selectionMode: Boolean = false,
+    savedWallpaperKeys: Set<String> = emptySet()
 ) {
     LazyVerticalGrid(
         modifier = modifier.fillMaxSize(),
-        columns = GridCells.Adaptive(minSize = 160.dp),
+        columns = GridCells.Fixed(2),
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 32.dp)
+        contentPadding = PaddingValues(bottom = 32.dp)
     ) {
         items(wallpapers, key = WallpaperItem::id) { wallpaper ->
+            val isSelected = wallpaper.id in selectedIds
+            val isSaved = wallpaper.libraryKey()?.let { it in savedWallpaperKeys } ?: false
             WallpaperCard(
                 item = wallpaper,
-                onClick = { onWallpaperSelected(wallpaper) }
+                isSelected = isSelected,
+                isSaved = isSaved,
+                selectionMode = selectionMode,
+                onClick = { onWallpaperSelected(wallpaper) },
+                onLongPress = onLongPress?.let { handler -> { handler(wallpaper) } }
             )
         }
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WallpaperCard(
     item: WallpaperItem,
+    isSelected: Boolean,
+    isSaved: Boolean,
+    selectionMode: Boolean,
     onClick: () -> Unit,
+    onLongPress: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
+    val aspectRatio = item.aspectRatio ?: DEFAULT_ASPECT_RATIO
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .aspectRatio(0.7f)
-            .clickable(onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
+            .aspectRatio(aspectRatio)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = { onLongPress?.invoke() }
+            ),
+        shape = RoundedCornerShape(18.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = if (isSelected) 8.dp else 4.dp),
+        border = if (isSelected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null
     ) {
         Box {
             AsyncImage(
@@ -75,6 +105,41 @@ fun WallpaperCard(
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
             )
+
+            if (selectionMode && !isSelected) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.1f))
+                )
+            }
+
+            if (isSelected) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.25f))
+                )
+                Icon(
+                    imageVector = Icons.Filled.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(8.dp)
+                )
+            }
+
+            if (isSaved) {
+                Icon(
+                    imageVector = Icons.Outlined.TaskAlt,
+                    contentDescription = stringResource(id = R.string.in_library),
+                    tint = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                )
+            }
 
             Box(
                 modifier = Modifier
@@ -110,3 +175,5 @@ fun WallpaperCard(
         }
     }
 }
+
+private const val DEFAULT_ASPECT_RATIO = 9f / 16f

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,4 +39,26 @@
     <string name="settings_appearance_header">Appearance</string>
     <string name="settings_dark_mode_title">Dark mode</string>
     <string name="settings_dark_mode_description">Use a dark theme throughout the app.</string>
+    <string name="settings_backup_header">Data &amp; backup</string>
+    <string name="settings_backup_export_title">Export library</string>
+    <string name="settings_backup_export_description">Save your sources, library, and albums as a backup file.</string>
+    <string name="settings_backup_export_action">Export</string>
+    <string name="settings_backup_export_in_progress">Exporting…</string>
+    <string name="settings_backup_import_title">Import backup</string>
+    <string name="settings_backup_import_description">Restore your sources, library, and albums from a backup file.</string>
+    <string name="settings_backup_import_action">Import</string>
+    <string name="settings_backup_import_in_progress">Importing…</string>
+    <string name="settings_backup_export_success">Backup saved.</string>
+    <string name="settings_backup_export_failure">Unable to export backup.</string>
+    <string name="settings_backup_export_failure_with_reason">Unable to export backup (%1$s).</string>
+    <string name="settings_backup_import_success">Backup imported.</string>
+    <string name="settings_backup_import_failure">Unable to import backup.</string>
+    <string name="settings_backup_import_failure_with_reason">Unable to import backup (%1$s).</string>
+    <string name="search_in_source">Search this source</string>
+    <string name="no_wallpapers_found">No wallpapers found.</string>
+    <string name="selection_count">%1$d selected</string>
+    <string name="selection_save_to_library">Save to library</string>
+    <string name="selection_add_to_album">Add to album</string>
+    <string name="select_album_title">Choose an album</string>
+    <string name="selection_no_albums">Create an album in your library to start organizing wallpapers.</string>
 </resources>


### PR DESCRIPTION
## Summary
- split the wallpaper apply/preview flow into Samsung and Pixel handlers with a default fallback
- add a database backup manager plus a settings view model to export and import the app's Room data
- expand the settings screen and activity wiring with backup actions and strings

## Testing
- `./gradlew lint` *(fails: Android SDK path is not configured; bundled KSP is also older than the Kotlin plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68cd83f91e588330bc44448144fa3f7b