### PR TITLE
Add API-backed wallpaper sources and supported URL dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-WallBase
+# WallBase
+
+WallBase is an Android app for collecting, organizing, and backing up a personal wallpaper library.
+
+## Highlights
+- Browse and save wallpapers into albums with customizable layouts and sorting options.
+- Connect Google Photos albums as wallpaper sources alongside local imports.
+- Back up and restore sources, library metadata, and downloaded media with a single package.
+

--- a/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
@@ -106,7 +106,6 @@ class MainActivity : ComponentActivity() {
                     sourcesUiState = sourcesUiState,
                     settingsUiState = settingsUiState,
                     onToggleDarkTheme = settingsViewModel::setDarkTheme,
-                    onSourceRepoUrlChanged = settingsViewModel::updateSourceRepoUrl,
                     onUpdateSourceInput = sourcesViewModel::updateSourceInput,
                     onSearchReddit = sourcesViewModel::searchRedditCommunities,
                     onAddSourceFromInput = sourcesViewModel::addSourceFromInput,
@@ -182,7 +181,6 @@ fun WallBaseApp(
     sourcesUiState: SourcesViewModel.SourcesUiState,
     settingsUiState: SettingsViewModel.SettingsUiState,
     onToggleDarkTheme: (Boolean) -> Unit,
-    onSourceRepoUrlChanged: (String) -> Unit,
     onUpdateSourceInput: (String) -> Unit,
     onSearchReddit: () -> Unit,
     onAddSourceFromInput: () -> Unit,
@@ -468,7 +466,6 @@ fun WallBaseApp(
                 SettingsScreen(
                     uiState = settingsUiState,
                     onToggleDarkTheme = onToggleDarkTheme,
-                    onSourceRepoUrlChanged = onSourceRepoUrlChanged,
                     onExportBackup = onExportBackup,
                     onImportBackup = onImportBackup,
                     onMessageShown = onSettingsMessageShown

--- a/app/src/main/java/com/joshiminh/wallbase/data/dao/RotationScheduleDao.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/dao/RotationScheduleDao.kt
@@ -1,0 +1,38 @@
+package com.joshiminh.wallbase.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.joshiminh.wallbase.data.entity.rotation.RotationScheduleEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RotationScheduleDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(schedule: RotationScheduleEntity): Long
+
+    @Query("SELECT * FROM rotation_schedules WHERE album_id = :albumId LIMIT 1")
+    fun observeSchedule(albumId: Long): Flow<RotationScheduleEntity?>
+
+    @Query("SELECT * FROM rotation_schedules WHERE album_id = :albumId LIMIT 1")
+    suspend fun getSchedule(albumId: Long): RotationScheduleEntity?
+
+    @Query("UPDATE rotation_schedules SET is_enabled = :enabled WHERE schedule_id = :scheduleId")
+    suspend fun updateEnabled(scheduleId: Long, enabled: Boolean)
+
+    @Query("UPDATE rotation_schedules SET interval_minutes = :interval WHERE schedule_id = :scheduleId")
+    suspend fun updateInterval(scheduleId: Long, interval: Long)
+
+    @Query("UPDATE rotation_schedules SET target = :target WHERE schedule_id = :scheduleId")
+    suspend fun updateTarget(scheduleId: Long, target: String)
+
+    @Query("UPDATE rotation_schedules SET last_applied_at = :appliedAt, last_wallpaper_id = :wallpaperId WHERE schedule_id = :scheduleId")
+    suspend fun updateLastApplied(scheduleId: Long, appliedAt: Long?, wallpaperId: Long?)
+
+    @Query("UPDATE rotation_schedules SET is_enabled = 0")
+    suspend fun disableAll()
+
+    @Query("SELECT * FROM rotation_schedules WHERE is_enabled = 1 LIMIT 1")
+    suspend fun getActiveSchedule(): RotationScheduleEntity?
+}

--- a/app/src/main/java/com/joshiminh/wallbase/data/dao/WallpaperDao.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/dao/WallpaperDao.kt
@@ -45,6 +45,13 @@ interface WallpaperDao {
     @Query("SELECT * FROM wallpapers WHERE local_uri IS NOT NULL AND TRIM(local_uri) != ''")
     suspend fun getWallpapersWithLocalMedia(): List<WallpaperEntity>
 
+    @Query(
+        "SELECT w.* FROM wallpapers w " +
+            "INNER JOIN album_wallpaper_cross_ref aw ON aw.wallpaper_id = w.wallpaper_id " +
+            "WHERE aw.album_id = :albumId ORDER BY w.added_at"
+    )
+    suspend fun getWallpapersForAlbum(albumId: Long): List<WallpaperEntity>
+
     @Query("DELETE FROM wallpapers WHERE source_key = :sourceKey AND remote_id = :remoteId")
     suspend fun deleteBySourceKeyAndRemoteId(sourceKey: String, remoteId: String): Int
 

--- a/app/src/main/java/com/joshiminh/wallbase/data/entity/rotation/RotationScheduleEntity.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/entity/rotation/RotationScheduleEntity.kt
@@ -1,0 +1,41 @@
+package com.joshiminh.wallbase.data.entity.rotation
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.joshiminh.wallbase.data.entity.album.AlbumEntity
+
+@Entity(
+    tableName = "rotation_schedules",
+    foreignKeys = [
+        ForeignKey(
+            entity = AlbumEntity::class,
+            parentColumns = ["album_id"],
+            childColumns = ["album_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["album_id"], unique = true),
+        Index(value = ["is_enabled"])
+    ]
+)
+data class RotationScheduleEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "schedule_id")
+    val id: Long = 0,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "interval_minutes")
+    val intervalMinutes: Long,
+    @ColumnInfo(name = "target")
+    val target: String,
+    @ColumnInfo(name = "is_enabled")
+    val isEnabled: Boolean,
+    @ColumnInfo(name = "last_applied_at")
+    val lastAppliedAt: Long? = null,
+    @ColumnInfo(name = "last_wallpaper_id")
+    val lastWallpaperId: Long? = null
+)

--- a/app/src/main/java/com/joshiminh/wallbase/data/entity/source/SourceKeys.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/entity/source/SourceKeys.kt
@@ -5,6 +5,10 @@ object SourceKeys {
     const val GOOGLE_DRIVE = "google_drive"
     const val REDDIT = "reddit"
     const val PINTEREST = "pinterest"
+    const val WALLHAVEN = "wallhaven"
+    const val DANBOORU = "danbooru"
+    const val UNSPLASH = "unsplash"
+    const val ALPHA_CODERS = "alpha_coders"
     const val WEBSITES = "websites"
     const val LOCAL = "local"
 }

--- a/app/src/main/java/com/joshiminh/wallbase/data/entity/source/SourceSeed.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/entity/source/SourceSeed.kt
@@ -2,8 +2,6 @@ package com.joshiminh.wallbase.data.entity.source
 
 import com.joshiminh.wallbase.sources.google_drive.GoogleDriveSource
 import com.joshiminh.wallbase.sources.google_photos.GooglePhotosSource
-import com.joshiminh.wallbase.sources.pinterest.PinterestSource
-import com.joshiminh.wallbase.sources.reddit.RedditSource
 
 /**
  * Describes a built-in source that should be preloaded into the local database on first launch.
@@ -24,8 +22,6 @@ data class SourceSeed(
 /** List of default sources bundled with the app. */
 val DefaultSources: List<SourceSeed> = listOf(
     GooglePhotosSource,
-    GoogleDriveSource,
-    RedditSource,
-    PinterestSource
+    GoogleDriveSource
 )
 

--- a/app/src/main/java/com/joshiminh/wallbase/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/repository/SettingsRepository.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.map
 import java.io.IOException
 
 /**
- * Persists simple user settings such as dark theme and custom source repository URLs.
+ * Persists simple user settings such as dark theme and layout preferences.
  */
 class SettingsRepository(
     private val dataStore: DataStore<Preferences>
@@ -37,7 +37,6 @@ class SettingsRepository(
 
             SettingsPreferences(
                 darkTheme = prefs[Keys.DARK_THEME] ?: false,
-                sourceRepoUrl = prefs[Keys.SOURCE_REPO_URL].orEmpty(),
                 wallpaperGridColumns = wallpaperColumns,
                 albumLayout = albumLayout,
                 wallpaperLayout = wallpaperLayout
@@ -47,17 +46,6 @@ class SettingsRepository(
     suspend fun setDarkTheme(enabled: Boolean) {
         dataStore.edit { prefs ->
             prefs[Keys.DARK_THEME] = enabled
-        }
-    }
-
-    suspend fun setSourceRepoUrl(url: String) {
-        val sanitized = url.trim()
-        dataStore.edit { prefs ->
-            if (sanitized.isBlank()) {
-                prefs.remove(Keys.SOURCE_REPO_URL)
-            } else {
-                prefs[Keys.SOURCE_REPO_URL] = sanitized
-            }
         }
     }
 
@@ -82,7 +70,6 @@ class SettingsRepository(
 
     private object Keys {
         val DARK_THEME = booleanPreferencesKey("dark_theme")
-        val SOURCE_REPO_URL = stringPreferencesKey("source_repo_url")
         val WALLPAPER_GRID_COLUMNS = intPreferencesKey("wallpaper_grid_columns")
         val ALBUM_LAYOUT = stringPreferencesKey("album_layout")
         val WALLPAPER_LAYOUT = stringPreferencesKey("wallpaper_layout")
@@ -97,7 +84,6 @@ class SettingsRepository(
 
 data class SettingsPreferences(
     val darkTheme: Boolean,
-    val sourceRepoUrl: String,
     val wallpaperGridColumns: Int,
     val albumLayout: AlbumLayout,
     val wallpaperLayout: WallpaperLayout
@@ -128,16 +114,19 @@ enum class AlbumLayout {
 
 enum class WallpaperLayout {
     GRID,
+    JUSTIFIED,
     LIST;
 
     val storageValue: String
         get() = when (this) {
             GRID -> "grid"
+            JUSTIFIED -> "justified"
             LIST -> "list"
         }
 
     companion object {
         fun fromStorage(value: String?): WallpaperLayout = when (value) {
+            "justified" -> JUSTIFIED
             "list" -> LIST
             else -> GRID
         }

--- a/app/src/main/java/com/joshiminh/wallbase/data/repository/WallpaperRepository.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/repository/WallpaperRepository.kt
@@ -10,6 +10,14 @@ import com.joshiminh.wallbase.sources.reddit.RedditPost
 import com.joshiminh.wallbase.sources.reddit.RedditService
 import com.joshiminh.wallbase.sources.reddit.RedditSubredditChild
 import com.joshiminh.wallbase.sources.reddit.RedditSubredditListingResponse
+import com.joshiminh.wallbase.sources.danbooru.DanbooruPost
+import com.joshiminh.wallbase.sources.danbooru.DanbooruService
+import com.joshiminh.wallbase.sources.unsplash.UnsplashPhoto
+import com.joshiminh.wallbase.sources.unsplash.UnsplashSearchResponse
+import com.joshiminh.wallbase.sources.unsplash.UnsplashService
+import com.joshiminh.wallbase.sources.wallhaven.WallhavenResponse
+import com.joshiminh.wallbase.sources.wallhaven.WallhavenService
+import com.joshiminh.wallbase.sources.wallhaven.WallhavenWallpaper
 import com.joshiminh.wallbase.util.network.WebScraper
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +31,9 @@ data class WallpaperPage(
 class WallpaperRepository(
     private val redditService: RedditService,
     private val webScraper: WebScraper,
+    private val wallhavenService: WallhavenService,
+    private val danbooruService: DanbooruService,
+    private val unsplashService: UnsplashService,
     private val pinterestQuery: String = DEFAULT_PINTEREST_QUERY,
     private val customWebsiteUrl: String = DEFAULT_CUSTOM_WEBSITE
 ) {
@@ -43,21 +54,56 @@ class WallpaperRepository(
                 )
             SourceKeys.PINTEREST -> {
                 val config = source.config
-                val wallpapers = when {
-                    trimmedQuery != null -> webScraper.scrapePinterest(trimmedQuery, limit = 30)
-                    config.isNullOrBlank() -> webScraper.scrapePinterest(pinterestQuery, limit = 30)
+                val scrapePage = when {
+                    trimmedQuery != null ->
+                        webScraper.scrapePinterest(trimmedQuery, limit = 30, cursor = cursor)
+                    config.isNullOrBlank() ->
+                        webScraper.scrapePinterest(pinterestQuery, limit = 30, cursor = cursor)
                     config.startsWith("http", ignoreCase = true) ->
-                        webScraper.scrapeImagesFromUrl(config, limit = 30)
-                    else -> webScraper.scrapePinterest(config, limit = 30)
+                        webScraper.scrapeImagesFromUrl(config, limit = 30, cursor = cursor)
+                    else -> webScraper.scrapePinterest(config, limit = 30, cursor = cursor)
                 }
-                WallpaperPage(wallpapers = wallpapers, nextCursor = null)
+                WallpaperPage(wallpapers = scrapePage.wallpapers, nextCursor = scrapePage.nextCursor)
+            }
+            SourceKeys.WALLHAVEN -> fetchWallhavenWallpapers(
+                config = source.config,
+                query = trimmedQuery,
+                cursor = cursor
+            )
+            SourceKeys.DANBOORU -> fetchDanbooruWallpapers(
+                config = source.config,
+                query = trimmedQuery,
+                cursor = cursor
+            )
+            SourceKeys.UNSPLASH -> fetchUnsplashWallpapers(
+                config = source.config,
+                query = trimmedQuery,
+                cursor = cursor
+            )
+            SourceKeys.ALPHA_CODERS -> {
+                val defaultUrl = source.config ?: DEFAULT_ALPHA_CODERS_URL
+                val targetUrl = trimmedQuery?.let { buildAlphaCodersSearchUrl(it) } ?: defaultUrl
+                val scrapePage = webScraper.scrapeImagesFromUrl(
+                    targetUrl,
+                    limit = 30,
+                    cursor = cursor
+                )
+                WallpaperPage(
+                    wallpapers = scrapePage.wallpapers,
+                    nextCursor = scrapePage.nextCursor
+                )
             }
             SourceKeys.WEBSITES -> {
                 val url = source.config ?: customWebsiteUrl
                 val targetUrl = trimmedQuery?.let { buildWebsiteSearchUrl(url, it) } ?: url
+                val scrapePage = webScraper.scrapeImagesFromUrl(
+                    targetUrl,
+                    limit = 30,
+                    cursor = cursor
+                )
                 WallpaperPage(
-                    wallpapers = webScraper.scrapeImagesFromUrl(targetUrl, limit = 30),
-                    nextCursor = null
+                    wallpapers = scrapePage.wallpapers,
+                    nextCursor = scrapePage.nextCursor
                 )
             }
             else -> WallpaperPage(emptyList(), nextCursor = null)
@@ -69,6 +115,136 @@ class WallpaperRepository(
             )
         }
         return WallpaperPage(wallpapers = mapped, nextCursor = page.nextCursor)
+    }
+
+    private suspend fun fetchWallhavenWallpapers(
+        config: String?,
+        query: String?,
+        cursor: String?
+    ): WallpaperPage = withContext(Dispatchers.IO) {
+        val parsed = parseWallhavenConfig(config)
+        val pageNumber = cursor?.toIntOrNull()?.takeIf { it > 0 } ?: 1
+        when (parsed.mode) {
+            WallhavenMode.COLLECTION -> {
+                val username = parsed.collectionUser
+                val collectionId = parsed.collectionId
+                if (username.isNullOrBlank() || collectionId.isNullOrBlank()) {
+                    WallpaperPage(emptyList(), nextCursor = null)
+                } else {
+                    runCatching {
+                        wallhavenService.getCollection(
+                            username = username,
+                            collectionId = collectionId,
+                            page = pageNumber,
+                            perPage = WALLHAVEN_PAGE_LIMIT
+                        )
+                    }.mapCatching { response ->
+                        response.toWallpaperPage(pageNumber)
+                    }.getOrElse { WallpaperPage(emptyList(), nextCursor = null) }
+                }
+            }
+
+            WallhavenMode.SEARCH -> {
+                val params = parsed.params.toMutableMap()
+                if (!query.isNullOrBlank()) {
+                    params["q"] = query
+                }
+                params.putIfAbsent("q", DEFAULT_WALLHAVEN_QUERY)
+                params["page"] = pageNumber.toString()
+                params.putIfAbsent("per_page", WALLHAVEN_PAGE_LIMIT.toString())
+                runCatching { wallhavenService.search(params) }
+                    .mapCatching { response -> response.toWallpaperPage(pageNumber) }
+                    .getOrElse { WallpaperPage(emptyList(), nextCursor = null) }
+            }
+        }
+    }
+
+    private suspend fun fetchDanbooruWallpapers(
+        config: String?,
+        query: String?,
+        cursor: String?
+    ): WallpaperPage = withContext(Dispatchers.IO) {
+        val pageNumber = cursor?.toIntOrNull()?.takeIf { it > 0 } ?: 1
+        val params = parseQueryParameters(config).toMutableMap()
+        val combinedTags = combineDanbooruTags(params["tags"], query)
+        params["tags"] = combinedTags ?: DEFAULT_DANBOORU_TAGS
+        params["page"] = pageNumber.toString()
+        params["limit"] = DANBOORU_PAGE_LIMIT.toString()
+        val posts = runCatching { danbooruService.getPosts(params) }.getOrElse { emptyList() }
+        val items = posts.mapNotNull { it.toWallpaperItem() }
+        val nextCursor = if (posts.size < DANBOORU_PAGE_LIMIT) null else (pageNumber + 1).toString()
+        WallpaperPage(items, nextCursor)
+    }
+
+    private suspend fun fetchUnsplashWallpapers(
+        config: String?,
+        query: String?,
+        cursor: String?
+    ): WallpaperPage = withContext(Dispatchers.IO) {
+        val perPage = UNSPLASH_PAGE_LIMIT
+        val pageNumber = cursor?.toIntOrNull()?.takeIf { it > 0 } ?: 1
+        when (val parsed = parseUnsplashConfig(config)) {
+            is UnsplashConfig.Collection -> {
+                val photos = runCatching {
+                    unsplashService.getCollectionPhotos(
+                        id = parsed.id,
+                        page = pageNumber,
+                        perPage = perPage
+                    )
+                }.getOrElse { emptyList() }
+                val items = photos.mapNotNull { it.toWallpaperItem() }
+                val nextCursor = if (photos.size < perPage) null else (pageNumber + 1).toString()
+                WallpaperPage(items, nextCursor)
+            }
+
+            is UnsplashConfig.UserLikes -> {
+                val photos = runCatching {
+                    unsplashService.getUserLikes(
+                        username = parsed.username,
+                        page = pageNumber,
+                        perPage = perPage
+                    )
+                }.getOrElse { emptyList() }
+                val items = photos.mapNotNull { it.toWallpaperItem() }
+                val nextCursor = if (photos.size < perPage) null else (pageNumber + 1).toString()
+                WallpaperPage(items, nextCursor)
+            }
+
+            is UnsplashConfig.UserPhotos -> {
+                val photos = runCatching {
+                    unsplashService.getUserPhotos(
+                        username = parsed.username,
+                        page = pageNumber,
+                        perPage = perPage
+                    )
+                }.getOrElse { emptyList() }
+                val items = photos.mapNotNull { it.toWallpaperItem() }
+                val nextCursor = if (photos.size < perPage) null else (pageNumber + 1).toString()
+                WallpaperPage(items, nextCursor)
+            }
+
+            is UnsplashConfig.Search -> {
+                val effectiveQuery = query?.takeIf { it.isNotBlank() }
+                    ?: parsed.query?.takeIf { it.isNotBlank() }
+                    ?: DEFAULT_UNSPLASH_QUERY
+                val response = runCatching {
+                    unsplashService.searchPhotos(
+                        query = effectiveQuery,
+                        page = pageNumber,
+                        perPage = perPage
+                    )
+                }.getOrElse { return@withContext WallpaperPage(emptyList(), nextCursor = null) }
+                val photos = response.results.orEmpty()
+                val items = photos.mapNotNull { it.toWallpaperItem() }
+                val nextCursor = when {
+                    response.totalPages != null && pageNumber < response.totalPages ->
+                        (pageNumber + 1).toString()
+                    photos.size < perPage -> null
+                    else -> (pageNumber + 1).toString()
+                }
+                WallpaperPage(items, nextCursor)
+            }
+        }
     }
 
     suspend fun searchRedditCommunities(query: String, limit: Int = 10): List<RedditCommunity> =
@@ -188,10 +364,198 @@ class WallpaperRepository(
         }
     }
 
+    private fun buildAlphaCodersSearchUrl(query: String): String {
+        val encoded = Uri.encode(query)
+        return "https://wall.alphacoders.com/search.php?search=$encoded"
+    }
+
+    private fun parseQueryParameters(config: String?): Map<String, String> {
+        if (config.isNullOrBlank()) return emptyMap()
+        val uri = runCatching { Uri.parse(config) }.getOrElse { return emptyMap() }
+        return uri.queryParameterNames.associateWith { name ->
+            uri.getQueryParameter(name).orEmpty()
+        }.filterValues { it.isNotBlank() }
+    }
+
+    private fun combineDanbooruTags(base: String?, query: String?): String? {
+        val tags = mutableListOf<String>()
+        if (!base.isNullOrBlank()) {
+            tags += base.trim().split(WHITESPACE_REGEX).filter { it.isNotBlank() }
+        }
+        if (!query.isNullOrBlank()) {
+            tags += query.trim().split(WHITESPACE_REGEX).filter { it.isNotBlank() }
+        }
+        if (tags.isEmpty()) return null
+        return tags.joinToString(" ") { it.replace(' ', '_') }
+    }
+
+    private fun parseWallhavenConfig(config: String?): WallhavenConfig {
+        if (config.isNullOrBlank()) {
+            return WallhavenConfig(mode = WallhavenMode.SEARCH)
+        }
+        val uri = runCatching { Uri.parse(config) }.getOrElse {
+            return WallhavenConfig(mode = WallhavenMode.SEARCH)
+        }
+        val segments = uri.pathSegments.filter { it.isNotBlank() }
+        if (segments.size >= 3 && segments[0].equals("collections", ignoreCase = true)) {
+            val username = segments.getOrNull(1)
+            val collectionId = segments.getOrNull(2)
+            if (!username.isNullOrBlank() && !collectionId.isNullOrBlank()) {
+                return WallhavenConfig(
+                    mode = WallhavenMode.COLLECTION,
+                    collectionUser = username,
+                    collectionId = collectionId
+                )
+            }
+        }
+
+        val params = mutableMapOf<String, String>()
+        uri.queryParameterNames.forEach { name ->
+            val value = uri.getQueryParameter(name)
+            if (!value.isNullOrBlank()) {
+                params[name] = value
+            }
+        }
+        val firstSegment = segments.firstOrNull()?.lowercase(Locale.ROOT)
+        when (firstSegment) {
+            "toplist" -> params.putIfAbsent("sorting", "toplist")
+            "latest" -> params.putIfAbsent("sorting", "date_added")
+            "random" -> params.putIfAbsent("sorting", "random")
+        }
+        return WallhavenConfig(mode = WallhavenMode.SEARCH, params = params)
+    }
+
+    private fun parseUnsplashConfig(config: String?): UnsplashConfig {
+        if (config.isNullOrBlank()) return UnsplashConfig.Search(query = null)
+        val uri = runCatching { Uri.parse(config) }.getOrElse {
+            return UnsplashConfig.Search(query = null)
+        }
+        val segments = uri.pathSegments.filter { it.isNotBlank() }
+        if (segments.size >= 3 && segments[0].equals("collections", ignoreCase = true)) {
+            val id = segments.getOrNull(1)
+            if (!id.isNullOrBlank()) {
+                return UnsplashConfig.Collection(id)
+            }
+        }
+        if (segments.size >= 2 && segments[0].equals("s", ignoreCase = true) &&
+            segments[1].equals("photos", ignoreCase = true)
+        ) {
+            val term = segments.drop(2)
+                .joinToString(" ") { it.replace('-', ' ') }
+                .takeIf { it.isNotBlank() }
+            val queryParam = uri.getQueryParameter("query")
+                ?: uri.getQueryParameter("q")
+                ?: term
+            return UnsplashConfig.Search(queryParam)
+        }
+        val first = segments.firstOrNull()
+        if (!first.isNullOrBlank() && first.startsWith("@")) {
+            val username = first.removePrefix("@")
+            val next = segments.getOrNull(1)
+            return when {
+                next.equals("likes", ignoreCase = true) -> UnsplashConfig.UserLikes(username)
+                else -> UnsplashConfig.UserPhotos(username)
+            }
+        }
+        val queryParam = uri.getQueryParameter("query") ?: uri.getQueryParameter("q")
+        return UnsplashConfig.Search(queryParam)
+    }
+
+    private fun WallhavenResponse.toWallpaperPage(requestedPage: Int): WallpaperPage {
+        val wallpapers = data.orEmpty().mapNotNull { it.toWallpaperItem() }
+        val current = meta?.currentPage
+        val last = meta?.lastPage
+        val nextCursor = when {
+            current != null && last != null && current < last -> (current + 1).toString()
+            wallpapers.size < WALLHAVEN_PAGE_LIMIT -> null
+            else -> (requestedPage + 1).toString()
+        }
+        return WallpaperPage(wallpapers, nextCursor)
+    }
+
+    private fun WallhavenWallpaper.toWallpaperItem(): WallpaperItem? {
+        val imageUrl = path ?: return null
+        val idValue = id?.takeIf { it.isNotBlank() } ?: imageUrl.hashCode().toString()
+        val titleValue = id?.let { "Wallhaven #$it" } ?: "Wallhaven wallpaper"
+        val sourceUrl = url ?: shortUrl ?: imageUrl
+        return WallpaperItem(
+            id = "wallhaven_$idValue",
+            title = titleValue,
+            imageUrl = imageUrl,
+            sourceUrl = sourceUrl,
+            width = dimensionX,
+            height = dimensionY
+        )
+    }
+
+    private fun DanbooruPost.toWallpaperItem(): WallpaperItem? {
+        val imageUrl = largeFileUrl ?: fileUrl ?: return null
+        val idValue = id?.toString() ?: imageUrl.hashCode().toString()
+        val titleValue = tagStringGeneral
+            ?.split('_', ' ')
+            ?.filter { it.isNotBlank() }
+            ?.joinToString(" ")
+            ?.replaceFirstChar { it.titlecase(Locale.ROOT) }
+            ?.takeIf { it.isNotBlank() }
+            ?: "Danbooru wallpaper"
+        val sourceUrl = id?.let { "https://danbooru.donmai.us/posts/$it" } ?: imageUrl
+        return WallpaperItem(
+            id = "danbooru_$idValue",
+            title = titleValue,
+            imageUrl = imageUrl,
+            sourceUrl = sourceUrl,
+            width = imageWidth,
+            height = imageHeight
+        )
+    }
+
+    private fun UnsplashPhoto.toWallpaperItem(): WallpaperItem? {
+        val imageUrl = urls?.full ?: urls?.raw ?: urls?.regular ?: return null
+        val idValue = id?.takeIf { it.isNotBlank() } ?: imageUrl.hashCode().toString()
+        val titleValue = description?.takeIf { it.isNotBlank() }
+            ?: altDescription?.takeIf { it.isNotBlank() }
+            ?: user?.name?.takeIf { it.isNotBlank() }?.let { "$it on Unsplash" }
+            ?: "Unsplash wallpaper"
+        val sourceUrl = links?.html ?: imageUrl
+        return WallpaperItem(
+            id = "unsplash_$idValue",
+            title = titleValue,
+            imageUrl = imageUrl,
+            sourceUrl = sourceUrl,
+            width = width,
+            height = height
+        )
+    }
+
+    private data class WallhavenConfig(
+        val mode: WallhavenMode,
+        val params: Map<String, String> = emptyMap(),
+        val collectionUser: String? = null,
+        val collectionId: String? = null
+    )
+
+    private enum class WallhavenMode { SEARCH, COLLECTION }
+
+    private sealed interface UnsplashConfig {
+        data class Search(val query: String?) : UnsplashConfig
+        data class Collection(val id: String) : UnsplashConfig
+        data class UserPhotos(val username: String) : UnsplashConfig
+        data class UserLikes(val username: String) : UnsplashConfig
+    }
+
     private companion object {
         private const val DEFAULT_REDDIT_SUBREDDIT = "wallpapers"
         private const val DEFAULT_PINTEREST_QUERY = "wallpaper backgrounds"
         private const val DEFAULT_CUSTOM_WEBSITE =
             "https://www.pixelstalk.net/category/wallpapers/4k-wallpapers/"
+        private const val DEFAULT_WALLHAVEN_QUERY = "wallpapers"
+        private const val DEFAULT_DANBOORU_TAGS = "wallpaper rating:s"
+        private const val DEFAULT_UNSPLASH_QUERY = "wallpapers"
+        private const val DEFAULT_ALPHA_CODERS_URL =
+            "https://wall.alphacoders.com/search.php?search=wallpaper"
+        private const val WALLHAVEN_PAGE_LIMIT = 30
+        private const val DANBOORU_PAGE_LIMIT = 30
+        private const val UNSPLASH_PAGE_LIMIT = 30
+        private val WHITESPACE_REGEX = Regex("\\s+")
     }
 }

--- a/app/src/main/java/com/joshiminh/wallbase/sources/danbooru/DanbooruService.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/sources/danbooru/DanbooruService.kt
@@ -1,0 +1,24 @@
+package com.joshiminh.wallbase.sources.danbooru
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.GET
+import retrofit2.http.QueryMap
+
+interface DanbooruService {
+    @GET("posts.json")
+    suspend fun getPosts(
+        @QueryMap options: Map<String, String>
+    ): List<DanbooruPost>
+}
+
+@JsonClass(generateAdapter = true)
+data class DanbooruPost(
+    @Json(name = "id") val id: Long?,
+    @Json(name = "file_url") val fileUrl: String?,
+    @Json(name = "large_file_url") val largeFileUrl: String?,
+    @Json(name = "preview_file_url") val previewFileUrl: String?,
+    @Json(name = "image_width") val imageWidth: Int?,
+    @Json(name = "image_height") val imageHeight: Int?,
+    @Json(name = "tag_string_general") val tagStringGeneral: String?
+)

--- a/app/src/main/java/com/joshiminh/wallbase/sources/unsplash/UnsplashService.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/sources/unsplash/UnsplashService.kt
@@ -1,0 +1,78 @@
+package com.joshiminh.wallbase.sources.unsplash
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface UnsplashService {
+    @Headers("Accept: application/json")
+    @GET("napi/search/photos")
+    suspend fun searchPhotos(
+        @Query("query") query: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int
+    ): UnsplashSearchResponse
+
+    @Headers("Accept: application/json")
+    @GET("napi/collections/{id}/photos")
+    suspend fun getCollectionPhotos(
+        @Path("id") id: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int
+    ): List<UnsplashPhoto>
+
+    @Headers("Accept: application/json")
+    @GET("napi/users/{username}/photos")
+    suspend fun getUserPhotos(
+        @Path("username") username: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int
+    ): List<UnsplashPhoto>
+
+    @Headers("Accept: application/json")
+    @GET("napi/users/{username}/likes")
+    suspend fun getUserLikes(
+        @Path("username") username: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int
+    ): List<UnsplashPhoto>
+}
+
+@JsonClass(generateAdapter = true)
+data class UnsplashSearchResponse(
+    @Json(name = "results") val results: List<UnsplashPhoto>?,
+    @Json(name = "total_pages") val totalPages: Int?
+)
+
+@JsonClass(generateAdapter = true)
+data class UnsplashPhoto(
+    @Json(name = "id") val id: String?,
+    @Json(name = "description") val description: String?,
+    @Json(name = "alt_description") val altDescription: String?,
+    @Json(name = "urls") val urls: UnsplashPhotoUrls?,
+    @Json(name = "links") val links: UnsplashPhotoLinks?,
+    @Json(name = "width") val width: Int?,
+    @Json(name = "height") val height: Int?,
+    @Json(name = "user") val user: UnsplashUser?
+)
+
+@JsonClass(generateAdapter = true)
+data class UnsplashPhotoUrls(
+    @Json(name = "raw") val raw: String?,
+    @Json(name = "full") val full: String?,
+    @Json(name = "regular") val regular: String?,
+    @Json(name = "small") val small: String?
+)
+
+@JsonClass(generateAdapter = true)
+data class UnsplashPhotoLinks(
+    @Json(name = "html") val html: String?
+)
+
+@JsonClass(generateAdapter = true)
+data class UnsplashUser(
+    @Json(name = "name") val name: String?
+)

--- a/app/src/main/java/com/joshiminh/wallbase/sources/wallhaven/WallhavenService.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/sources/wallhaven/WallhavenService.kt
@@ -1,0 +1,45 @@
+package com.joshiminh.wallbase.sources.wallhaven
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+import retrofit2.http.QueryMap
+
+interface WallhavenService {
+    @GET("search")
+    suspend fun search(
+        @QueryMap options: Map<String, String>
+    ): WallhavenResponse
+
+    @GET("collections/{username}/{collectionId}")
+    suspend fun getCollection(
+        @Path("username") username: String,
+        @Path("collectionId") collectionId: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int
+    ): WallhavenResponse
+}
+
+@JsonClass(generateAdapter = true)
+data class WallhavenResponse(
+    @Json(name = "data") val data: List<WallhavenWallpaper>?,
+    @Json(name = "meta") val meta: WallhavenMeta?
+)
+
+@JsonClass(generateAdapter = true)
+data class WallhavenWallpaper(
+    @Json(name = "id") val id: String?,
+    @Json(name = "url") val url: String?,
+    @Json(name = "short_url") val shortUrl: String?,
+    @Json(name = "path") val path: String?,
+    @Json(name = "dimension_x") val dimensionX: Int?,
+    @Json(name = "dimension_y") val dimensionY: Int?
+)
+
+@JsonClass(generateAdapter = true)
+data class WallhavenMeta(
+    @Json(name = "current_page") val currentPage: Int?,
+    @Json(name = "last_page") val lastPage: Int?
+)

--- a/app/src/main/java/com/joshiminh/wallbase/ui/DriveFolderPickerScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/DriveFolderPickerScreen.kt
@@ -47,7 +47,7 @@ fun DriveFolderPickerScreen(
         folders = emptyList()
         if (token.isBlank()) {
             loading = false
-            errorMessage = "Missing Google Drive authentication token."
+            errorMessage = "Missing google drive/photos authentication token"
             return@LaunchedEffect
         }
 

--- a/app/src/main/java/com/joshiminh/wallbase/ui/GooglePhotosAlbumPickerScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/GooglePhotosAlbumPickerScreen.kt
@@ -47,7 +47,7 @@ fun GooglePhotosAlbumPickerScreen(
         albums = emptyList()
         if (token.isBlank()) {
             loading = false
-            errorMessage = "Missing Google Photos authentication token."
+            errorMessage = "Missing google drive/photos authentication token"
             return@LaunchedEffect
         }
 

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -14,14 +14,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -35,7 +34,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.joshiminh.wallbase.ui.viewmodel.SettingsViewModel
@@ -44,7 +42,6 @@ import com.joshiminh.wallbase.ui.viewmodel.SettingsViewModel
 fun SettingsScreen(
     uiState: SettingsViewModel.SettingsUiState,
     onToggleDarkTheme: (Boolean) -> Unit,
-    onSourceRepoUrlChanged: (String) -> Unit,
     onExportBackup: () -> Unit,
     onImportBackup: () -> Unit,
     onMessageShown: () -> Unit
@@ -105,50 +102,6 @@ fun SettingsScreen(
                             Switch(
                                 checked = uiState.darkTheme,
                                 onCheckedChange = onToggleDarkTheme
-                            )
-                        }
-                    }
-                }
-            }
-
-            item {
-                SettingsSection(spacing = 12.dp) {
-                    Text(
-                        text = "Sources",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-
-                    SettingsCard {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 20.dp, vertical = 16.dp),
-                            verticalArrangement = Arrangement.spacedBy(12.dp)
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                Text(
-                                    text = "Source repository",
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                                Text(
-                                    text = "Paste a JSON feed that lists wallpaper sources to import.",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-
-                            OutlinedTextField(
-                                value = uiState.sourceRepoUrl,
-                                onValueChange = onSourceRepoUrlChanged,
-                                modifier = Modifier.fillMaxWidth(),
-                                singleLine = true,
-                                placeholder = {
-                                    Text("https://example.com/wallbase-sources.json")
-                                },
-                                keyboardOptions = KeyboardOptions.Default.copy(
-                                    imeAction = ImeAction.Done
-                                )
                             )
                         }
                     }
@@ -247,66 +200,73 @@ fun SettingsScreen(
                     }
 
                     SettingsCard {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 20.dp, vertical = 16.dp),
-                            horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Text(
-                                    text = "Export library",
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                                Text(
-                                    text = "Save your sources, library, and albums as a backup file.",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Text(
+                                        text = "Export library",
+                                        style = MaterialTheme.typography.titleMedium
+                                    )
+                                    Text(
+                                        text = "Save your sources, library, and albums as a backup file.",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+
+                                SettingsActionButton(
+                                    text = if (uiState.isBackingUp) "Exporting…" else "Export",
+                                    enabled = !uiState.isBackingUp && !uiState.isRestoring,
+                                    showProgress = uiState.isBackingUp,
+                                    onClick = onExportBackup
                                 )
                             }
 
-                            SettingsActionButton(
-                                text = if (uiState.isBackingUp) "Exporting…" else "Export",
-                                enabled = !uiState.isBackingUp && !uiState.isRestoring,
-                                showProgress = uiState.isBackingUp,
-                                onClick = onExportBackup
+                            Divider(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant
                             )
-                        }
-                    }
 
-                    SettingsCard {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 20.dp, vertical = 16.dp),
-                            horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Text(
-                                    text = "Import backup",
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                                Text(
-                                    text = "Restore your sources, library, and albums from a backup file.",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Text(
+                                        text = "Import backup",
+                                        style = MaterialTheme.typography.titleMedium
+                                    )
+                                    Text(
+                                        text = "Restore your sources, library, and albums from a backup file.",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+
+                                SettingsActionButton(
+                                    text = if (uiState.isRestoring) "Importing…" else "Import",
+                                    enabled = !uiState.isRestoring && !uiState.isBackingUp,
+                                    showProgress = uiState.isRestoring,
+                                    onClick = onImportBackup
                                 )
                             }
-
-                            SettingsActionButton(
-                                text = if (uiState.isRestoring) "Importing…" else "Import",
-                                enabled = !uiState.isRestoring && !uiState.isBackingUp,
-                                showProgress = uiState.isRestoring,
-                                onClick = onImportBackup
-                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseScreen.kt
@@ -317,17 +317,16 @@ private fun SourceBrowseScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             state.errorMessage?.takeIf { state.wallpapers.isEmpty() }?.let { message ->
                 Text(
                     text = message,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(top = 8.dp)
+                    modifier = Modifier.padding(top = 4.dp)
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
             PullToRefreshBox(
                 isRefreshing = state.isRefreshing,
@@ -390,7 +389,7 @@ private fun SourceBrowseScreen(
                     text = message,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.padding(top = 8.dp)
+                    modifier = Modifier.padding(top = 4.dp)
                 )
             }
         }
@@ -421,7 +420,7 @@ private fun AlbumPickerDialog(
             if (albums.isEmpty()) {
                 Text(text = "Create an album in your library to start organizing wallpapers.")
             } else {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     albums.forEach { album ->
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
@@ -430,7 +429,7 @@ private fun AlbumPickerDialog(
                             onClick = { onAlbumSelected(album) }
                         ) {
                             Column(
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
                             ) {
                                 Text(
                                     text = album.title,
@@ -461,7 +460,7 @@ private fun ErrorMessage(message: String, onRetry: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(24.dp),
+            .padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -469,7 +468,7 @@ private fun ErrorMessage(message: String, onRetry: () -> Unit) {
             text = message,
             color = MaterialTheme.colorScheme.error,
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(bottom = 12.dp)
+            modifier = Modifier.padding(bottom = 4.dp)
         )
         Button(onClick = onRetry) {
             Text("Retry")

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/LayoutSelectors.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/LayoutSelectors.kt
@@ -59,6 +59,7 @@ fun WallpaperLayoutPicker(
                     label = {
                         val text = when (layout) {
                             WallpaperLayout.GRID -> "Grid"
+                            WallpaperLayout.JUSTIFIED -> "Justified"
                             WallpaperLayout.LIST -> "List"
                         }
                         Text(text = text)

--- a/app/src/main/java/com/joshiminh/wallbase/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/viewmodel/SettingsViewModel.kt
@@ -40,7 +40,6 @@ class SettingsViewModel(
                 _uiState.update {
                     it.copy(
                         darkTheme = preferences.darkTheme,
-                        sourceRepoUrl = preferences.sourceRepoUrl,
                         wallpaperGridColumns = preferences.wallpaperGridColumns,
                         albumLayout = preferences.albumLayout
                     )
@@ -119,20 +118,11 @@ class SettingsViewModel(
         }
     }
 
-    fun updateSourceRepoUrl(url: String) {
-        if (_uiState.value.sourceRepoUrl == url) return
-        _uiState.update { it.copy(sourceRepoUrl = url) }
-        viewModelScope.launch {
-            settingsRepository.setSourceRepoUrl(url)
-        }
-    }
-
     data class SettingsUiState(
         val isBackingUp: Boolean = false,
         val isRestoring: Boolean = false,
         val message: String? = null,
         val darkTheme: Boolean = false,
-        val sourceRepoUrl: String = "",
         val wallpaperGridColumns: Int = 2,
         val albumLayout: AlbumLayout = AlbumLayout.CARD_LIST,
         val storageBytes: Long? = null,

--- a/app/src/main/java/com/joshiminh/wallbase/util/network/JsoupWebScraper.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/network/JsoupWebScraper.kt
@@ -1,43 +1,76 @@
 package com.joshiminh.wallbase.util.network
 
 import com.joshiminh.wallbase.data.entity.wallpaper.WallpaperItem
+import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.LinkedHashSet
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jsoup.Connection
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import org.json.JSONArray
+import org.json.JSONObject
 
 class JsoupWebScraper : WebScraper {
 
-    override suspend fun scrapePinterest(query: String, limit: Int): List<WallpaperItem> = runCatching {
+    override suspend fun scrapePinterest(
+        query: String,
+        limit: Int,
+        cursor: String?,
+    ): ScrapePage = runCatching {
         val encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8.toString())
         val url = "https://www.pinterest.com/search/pins/?q=$encodedQuery"
-        extractImages(url, limit) { element ->
+        extractImages(url, limit, cursor) { element ->
             element.attr("alt").ifBlank { "Pinterest Pin" }
         }
-    }.getOrElse { emptyList() }
+    }.getOrElse { ScrapePage(emptyList(), nextCursor = null) }
 
-    override suspend fun scrapeImagesFromUrl(url: String, limit: Int): List<WallpaperItem> = runCatching {
-        extractImages(url, limit) { element ->
-            element.attr("alt").ifBlank { element.attr("title") }
+    override suspend fun scrapeImagesFromUrl(
+        url: String,
+        limit: Int,
+        cursor: String?,
+    ): ScrapePage {
+        val uri = runCatching { URI(url) }.getOrNull()
+        val host = uri?.host?.lowercase(Locale.ROOT) ?: ""
+        val specialized = when {
+            host.contains("pinterest.") -> runCatching {
+                scrapePinterestUrl(url, limit, cursor)
+            }.getOrNull()
+            host.endsWith("photos.google.com") || host == "photos.app.goo.gl" -> runCatching {
+                scrapeGooglePhotosAlbum(url, limit, cursor)
+            }.getOrNull()
+            host.contains("drive.google.com") -> runCatching {
+                scrapeGoogleDriveFolder(url, limit, cursor)
+            }.getOrNull()
+            else -> null
         }
-    }.getOrElse { emptyList() }
+        if (specialized != null) return specialized
+
+        return runCatching {
+            extractImages(url, limit, cursor) { element ->
+                element.attr("alt").ifBlank { element.attr("title") }
+            }
+        }.getOrElse { ScrapePage(emptyList(), nextCursor = null) }
+    }
 
     private suspend fun extractImages(
         pageUrl: String,
         limit: Int,
+        cursor: String?,
         titleProvider: (Element) -> String
-    ): List<WallpaperItem> = withContext(Dispatchers.IO) {
+    ): ScrapePage = withContext(Dispatchers.IO) {
         val document = fetch(pageUrl)
         val seen = LinkedHashSet<String>()
         val results = mutableListOf<WallpaperItem>()
+        val offset = cursor?.toIntOrNull()?.takeIf { it >= 0 } ?: 0
+        val maxToCollect = offset + limit + 1
 
         document.select(IMAGE_SELECTOR).forEach { element ->
-            if (results.size >= limit) return@forEach
+            if (results.size >= maxToCollect) return@forEach
 
             val resolvedUrl = element.extractImageUrl()?.replace("&amp;", "&") ?: return@forEach
             if (!resolvedUrl.startsWith("http", ignoreCase = true) || !resolvedUrl.hasSupportedExtension()) {
@@ -57,7 +90,16 @@ class JsoupWebScraper : WebScraper {
             )
         }
 
-        results
+        val fromIndex = offset.coerceAtMost(results.size)
+        val toIndex = (fromIndex + limit).coerceAtMost(results.size)
+        val pageItems = if (fromIndex >= toIndex) {
+            emptyList()
+        } else {
+            results.subList(fromIndex, toIndex).toList()
+        }
+        val hasMore = results.size > toIndex
+        val nextCursor = if (hasMore) toIndex.toString() else null
+        ScrapePage(pageItems, nextCursor)
     }
 
     private fun fetch(url: String): Document =
@@ -67,12 +109,383 @@ class JsoupWebScraper : WebScraper {
             .timeout(TIMEOUT_MS)
             .get()
 
+    private suspend fun scrapePinterestUrl(
+        pageUrl: String,
+        limit: Int,
+        cursor: String?,
+    ): ScrapePage? {
+        if (cursor.isNullOrBlank()) {
+            val info = parsePinterestUrl(pageUrl) ?: return null
+            return runCatching {
+                val document = fetch(pageUrl)
+                parsePinterestInitialPage(document, info, limit)
+            }.getOrNull()
+        }
+
+        val parsedCursor = PinterestCursor.decode(cursor) ?: return null
+        return runCatching {
+            fetchPinterestContinuation(parsedCursor)
+        }.getOrNull()
+    }
+
+    private suspend fun scrapeGooglePhotosAlbum(
+        pageUrl: String,
+        limit: Int,
+        cursor: String?,
+    ): ScrapePage? = withContext(Dispatchers.IO) {
+        val document = runCatching { fetch(pageUrl) }.getOrElse { return@withContext null }
+        val images = extractGooglePhotosImages(document.html())
+        if (images.isEmpty()) return@withContext null
+        val offset = cursor?.toIntOrNull()?.takeIf { it >= 0 } ?: 0
+        val fromIndex = offset.coerceAtMost(images.size)
+        val toIndex = (fromIndex + limit).coerceAtMost(images.size)
+        if (fromIndex >= toIndex) {
+            return@withContext ScrapePage(emptyList(), nextCursor = null)
+        }
+        val pageItems = images.subList(fromIndex, toIndex).mapIndexed { index, imageUrl ->
+            val absoluteIndex = fromIndex + index + 1
+            WallpaperItem(
+                id = "google_photos_${imageUrl.hashCode()}",
+                title = "Google Photos image $absoluteIndex",
+                imageUrl = imageUrl,
+                sourceUrl = pageUrl
+            )
+        }
+        val nextCursor = if (toIndex < images.size) toIndex.toString() else null
+        ScrapePage(pageItems, nextCursor)
+    }
+
+    private suspend fun scrapeGoogleDriveFolder(
+        pageUrl: String,
+        limit: Int,
+        cursor: String?,
+    ): ScrapePage? = withContext(Dispatchers.IO) {
+        val folderId = parseGoogleDriveFolderId(pageUrl) ?: return@withContext null
+        val embedUrl = "https://drive.google.com/embeddedfolderview?id=$folderId#grid"
+        val document = runCatching { fetch(embedUrl) }.getOrElse { return@withContext null }
+        val fileIds = LinkedHashSet<String>()
+        val items = mutableListOf<WallpaperItem>()
+        val anchors = document.select("a[href*=/file/d/]")
+        anchors.forEach { anchor ->
+            val href = anchor.absUrl("href").ifBlank { anchor.attr("href") }
+            val match = DRIVE_FILE_REGEX.find(href) ?: return@forEach
+            val fileId = match.groupValues.getOrNull(1)?.takeIf { it.isNotBlank() } ?: return@forEach
+            if (!fileIds.add(fileId)) return@forEach
+            if (anchor.selectFirst("img[src]") == null) return@forEach
+            val title = anchor.attr("title")
+                .ifBlank { anchor.text() }
+                .ifBlank { "Google Drive image" }
+            val imageUrl = "https://drive.google.com/uc?export=view&id=$fileId"
+            val sourceUrl = "https://drive.google.com/file/d/$fileId/view"
+            items += WallpaperItem(
+                id = fileId,
+                title = title,
+                imageUrl = imageUrl,
+                sourceUrl = sourceUrl
+            )
+        }
+        if (items.isEmpty()) return@withContext null
+        val offset = cursor?.toIntOrNull()?.takeIf { it >= 0 } ?: 0
+        val fromIndex = offset.coerceAtMost(items.size)
+        val toIndex = (fromIndex + limit).coerceAtMost(items.size)
+        if (fromIndex >= toIndex) {
+            return@withContext ScrapePage(emptyList(), nextCursor = null)
+        }
+        val pageItems = items.subList(fromIndex, toIndex).mapIndexed { index, item ->
+            val absoluteIndex = fromIndex + index + 1
+            val label = item.title.ifBlank { "Google Drive image $absoluteIndex" }
+            item.copy(title = label)
+        }
+        val nextCursor = if (toIndex < items.size) toIndex.toString() else null
+        ScrapePage(pageItems, nextCursor)
+    }
+
+    private fun parseGoogleDriveFolderId(pageUrl: String): String? {
+        val uri = runCatching { URI(pageUrl) }.getOrNull() ?: return null
+        val pathSegments = uri.path.split('/').filter { it.isNotBlank() }
+        val folderIndex = pathSegments.indexOfFirst { it.equals("folders", ignoreCase = true) }
+        if (folderIndex >= 0 && folderIndex + 1 < pathSegments.size) {
+            return pathSegments[folderIndex + 1]
+        }
+        val query = uri.query ?: return null
+        return query.split('&')
+            .mapNotNull { part ->
+                val pieces = part.split('=')
+                if (pieces.size == 2 && pieces[0] == "id") pieces[1] else null
+            }
+            .firstOrNull { it.isNotBlank() }
+    }
+
+    private fun extractGooglePhotosImages(html: String): List<String> {
+        val matches = GOOGLE_PHOTOS_REGEX.findAll(html)
+        val urls = LinkedHashSet<String>()
+        matches.forEach { match ->
+            var url = match.value
+            url = url
+                .replace("\\u003d", "=")
+                .replace("\\u0026", "&")
+                .replace("&amp;", "&")
+            val cleaned = normalizeGooglePhotosUrl(url)
+            urls.add(cleaned)
+        }
+        return urls.toList()
+    }
+
+    private fun normalizeGooglePhotosUrl(url: String): String {
+        val anchor = when {
+            "=w" in url -> url.substringBefore("=w")
+            "=s" in url -> url.substringBefore("=s")
+            "=h" in url -> url.substringBefore("=h")
+            "=d" in url -> url.substringBefore("=d")
+            "=m" in url -> url.substringBefore("=m")
+            else -> url
+        }
+        val sanitized = anchor.removeSuffix("-no").removeSuffix("-rw")
+        if (sanitized.contains("=w") || sanitized.contains("=s") || sanitized.contains("=h")) {
+            return sanitized
+        }
+        val separator = if (sanitized.contains('?')) '&' else '='
+        return "$sanitized${separator}w4096-h4096"
+    }
+
+    private fun parsePinterestInitialPage(
+        document: Document,
+        info: PinterestUrlInfo,
+        limit: Int,
+    ): ScrapePage? {
+        val scripts = document.select("script[id=__PWS_DATA__], script[id=__PWS_INITIAL_PROPS__]")
+        scripts.forEach { element ->
+            val data = element.data().takeIf { it.isNotBlank() } ?: return@forEach
+            val root = runCatching { JSONObject(data) }.getOrNull() ?: return@forEach
+            val resourceName = info.type.resourceName
+            val resource = root.findPinterestResource(resourceName) ?: return@forEach
+            val response = resource.optJSONObject("resource_response") ?: return@forEach
+            val dataArray = response.optJSONArray("data") ?: JSONArray()
+            val pins = parsePinterestPins(dataArray)
+            val bookmark = response.optString("bookmark").takeIf { it.isNotBlank() }
+            val options = resource.optJSONObject("resource")?.optJSONObject("options")
+            val boardId = options?.optString("board_id").takeIf { !it.isNullOrBlank() }
+            val slug = options?.optString("slug").takeIf { !it.isNullOrBlank() } ?: info.boardSlug
+            val pageSize = options?.optInt("page_size").takeIf { it > 0 } ?: limit
+            val nextCursor = bookmark?.let {
+                PinterestCursor(
+                    type = resourceName,
+                    username = info.username,
+                    slug = slug,
+                    boardId = boardId,
+                    pagePath = ensurePinterestPath(info.pagePath),
+                    bookmark = it,
+                    pageSize = pageSize
+                ).encode()
+            }
+            if (pins.isNotEmpty()) {
+                return ScrapePage(pins, nextCursor)
+            }
+        }
+        return null
+    }
+
+    private suspend fun fetchPinterestContinuation(cursor: PinterestCursor): ScrapePage? =
+        withContext(Dispatchers.IO) {
+            val endpoint = when (cursor.type) {
+                PinterestResourceType.BOARD.resourceName -> PINTEREST_BOARD_ENDPOINT
+                PinterestResourceType.USER_PINS.resourceName -> PINTEREST_USER_PINS_ENDPOINT
+                else -> return@withContext null
+            }
+            val options = JSONObject().apply {
+                put("isPrefetch", false)
+                put("page_size", cursor.pageSize)
+                put("bookmarks", JSONArray().apply { put(cursor.bookmark) })
+                cursor.boardId?.let { put("board_id", it) }
+                cursor.slug?.let { put("slug", it) }
+                cursor.username?.let { put("username", it) }
+            }
+            val payload = JSONObject()
+                .put("options", options)
+                .put("context", JSONObject())
+            val responseBody = Jsoup.connect(endpoint)
+                .ignoreContentType(true)
+                .method(Connection.Method.GET)
+                .userAgent(USER_AGENT)
+                .referrer("https://www.google.com")
+                .timeout(TIMEOUT_MS)
+                .header("Accept", "application/json, text/javascript, */*; q=0.01")
+                .header("X-Requested-With", "XMLHttpRequest")
+                .data("source_url", cursor.pagePath)
+                .data("data", payload.toString())
+                .data("_", System.currentTimeMillis().toString())
+                .execute()
+                .body()
+            val json = runCatching { JSONObject(responseBody) }.getOrNull() ?: return@withContext null
+            val response = json.optJSONObject("resource_response") ?: return@withContext null
+            val data = response.optJSONArray("data") ?: JSONArray()
+            val pins = parsePinterestPins(data)
+            val bookmark = response.optString("bookmark").takeIf { it.isNotBlank() }
+            val nextCursor = bookmark?.let { cursor.copy(bookmark = it).encode() }
+            ScrapePage(pins, nextCursor)
+        }
+
+    private fun parsePinterestPins(data: JSONArray): List<WallpaperItem> {
+        val items = mutableListOf<WallpaperItem>()
+        for (index in 0 until data.length()) {
+            val pin = data.optJSONObject(index) ?: continue
+            val id = pin.optString("id").takeIf { it.isNotBlank() } ?: continue
+            val images = pin.optJSONObject("images") ?: continue
+            val imageUrl = PINTEREST_IMAGE_ORDER.asSequence()
+                .mapNotNull { sizeKey ->
+                    images.optJSONObject(sizeKey)?.optString("url")?.takeIf { it.isNotBlank() }
+                }
+                .firstOrNull()
+                ?.replace("\\u0026", "&")
+                ?.replace("\\u003d", "=")
+                ?: continue
+            val title = pin.optString("title")
+                .ifBlank { pin.optString("grid_title") }
+                .ifBlank { pin.optJSONObject("grid_description")?.optString("text") }
+                .ifBlank { "Pinterest Pin" }
+            val sourceUrl = pin.optString("link")
+                .ifBlank { pin.optString("seo_link") }
+                .ifBlank { "https://www.pinterest.com/pin/$id/" }
+            val orig = images.optJSONObject("orig")
+            val width = orig?.optInt("width")?.takeIf { it > 0 }
+            val height = orig?.optInt("height")?.takeIf { it > 0 }
+            items += WallpaperItem(
+                id = id,
+                title = title,
+                imageUrl = imageUrl,
+                sourceUrl = sourceUrl,
+                width = width,
+                height = height
+            )
+        }
+        return items
+    }
+
+    private fun JSONObject.findPinterestResource(name: String): JSONObject? {
+        optJSONArray("resourceResponses")?.let { array ->
+            for (index in 0 until array.length()) {
+                val candidate = array.optJSONObject(index)
+                if (candidate?.optString("name") == name) {
+                    return candidate
+                }
+            }
+        }
+        val iterator = keys()
+        while (iterator.hasNext()) {
+            val key = iterator.next()
+            val value = opt(key)
+            when (value) {
+                is JSONObject -> {
+                    val match = value.findPinterestResource(name)
+                    if (match != null) return match
+                }
+                is JSONArray -> {
+                    for (i in 0 until value.length()) {
+                        val child = value.optJSONObject(i) ?: continue
+                        val match = child.findPinterestResource(name)
+                        if (match != null) return match
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun parsePinterestUrl(pageUrl: String): PinterestUrlInfo? {
+        val uri = runCatching { URI(pageUrl) }.getOrNull() ?: return null
+        val host = uri.host?.lowercase(Locale.ROOT) ?: return null
+        if (!host.contains("pinterest.")) return null
+        val segments = uri.path.split('/').filter { it.isNotBlank() }
+        if (segments.isEmpty()) return null
+        val username = segments[0]
+        if (username.isBlank()) return null
+        val defaultPath = if (segments.size >= 2) uri.path else "/$username/_pins/"
+        val pagePath = ensurePinterestPath(defaultPath)
+        return when {
+            segments.size >= 2 && segments[1].equals("_pins", ignoreCase = true) ->
+                PinterestUrlInfo(PinterestResourceType.USER_PINS, username, null, pagePath)
+            segments.size >= 2 && segments[1].equals("_created", ignoreCase = true) ->
+                PinterestUrlInfo(PinterestResourceType.USER_PINS, username, null, pagePath)
+            segments.size >= 2 -> {
+                val slug = segments[1]
+                PinterestUrlInfo(PinterestResourceType.BOARD, username, slug, pagePath)
+            }
+            else -> PinterestUrlInfo(
+                PinterestResourceType.USER_PINS,
+                username,
+                null,
+                ensurePinterestPath("/$username/_pins/")
+            )
+        }
+    }
+
+    private fun ensurePinterestPath(path: String): String {
+        val trimmed = if (path.startsWith("/")) path else "/$path"
+        return if (trimmed.endsWith("/")) trimmed else "$trimmed/"
+    }
+
+    private data class PinterestUrlInfo(
+        val type: PinterestResourceType,
+        val username: String,
+        val boardSlug: String?,
+        val pagePath: String
+    )
+
+    private enum class PinterestResourceType(val resourceName: String) {
+        BOARD("BoardFeedResource"),
+        USER_PINS("UserPinsResource")
+    }
+
+    private data class PinterestCursor(
+        val type: String,
+        val username: String?,
+        val slug: String?,
+        val boardId: String?,
+        val pagePath: String,
+        val bookmark: String,
+        val pageSize: Int
+    ) {
+        fun encode(): String = JSONObject().apply {
+            put("type", type)
+            put("username", username)
+            put("slug", slug)
+            put("boardId", boardId)
+            put("pagePath", pagePath)
+            put("bookmark", bookmark)
+            put("pageSize", pageSize)
+        }.toString()
+
+        companion object {
+            fun decode(raw: String): PinterestCursor? = runCatching {
+                val json = JSONObject(raw)
+                val type = json.optString("type").takeIf { it.isNotBlank() } ?: return@runCatching null
+                val pathValue = json.optString("pagePath").takeIf { it.isNotBlank() } ?: return@runCatching null
+                val bookmark = json.optString("bookmark").takeIf { it.isNotBlank() } ?: return@runCatching null
+                val pageSize = json.optInt("pageSize").takeIf { it > 0 } ?: 30
+                PinterestCursor(
+                    type = type,
+                    username = json.optString("username").takeIf { it.isNotBlank() },
+                    slug = json.optString("slug").takeIf { it.isNotBlank() },
+                    boardId = json.optString("boardId").takeIf { it.isNotBlank() },
+                    pagePath = ensurePinterestPath(pathValue),
+                    bookmark = bookmark,
+                    pageSize = pageSize
+                )
+            }.getOrNull()
+        }
+    }
+
     private companion object {
         private const val TIMEOUT_MS = 15_000
         private const val USER_AGENT =
             "Mozilla/5.0 (Linux; Android 14; WallBase) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36"
         private const val IMAGE_SELECTOR = "img[src], img[data-src], img[data-lazy-src], img[data-original], img[data-actualsrc]"
         private val IMAGE_ATTRIBUTES = listOf("src", "data-src", "data-lazy-src", "data-original", "data-actualsrc")
+        private val PINTEREST_IMAGE_ORDER = listOf("orig", "736x", "600x", "564x", "474x", "236x")
+        private val GOOGLE_PHOTOS_REGEX = Regex("https://lh[0-9]\\.googleusercontent\\.com/[^\\"\\s<>]+", RegexOption.IGNORE_CASE)
+        private val DRIVE_FILE_REGEX = Regex("/file/d/([a-zA-Z0-9_-]+)")
+        private const val PINTEREST_BOARD_ENDPOINT = "https://www.pinterest.com/resource/BoardFeedResource/get/"
+        private const val PINTEREST_USER_PINS_ENDPOINT = "https://www.pinterest.com/resource/UserPinsResource/get/"
     }
 
     private fun Element.extractImageUrl(): String? {

--- a/app/src/main/java/com/joshiminh/wallbase/util/network/WebScraper.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/network/WebScraper.kt
@@ -2,8 +2,21 @@ package com.joshiminh.wallbase.util.network
 
 import com.joshiminh.wallbase.data.entity.wallpaper.WallpaperItem
 
-interface WebScraper {
-    suspend fun scrapePinterest(query: String, limit: Int = 30): List<WallpaperItem>
+data class ScrapePage(
+    val wallpapers: List<WallpaperItem>,
+    val nextCursor: String?
+)
 
-    suspend fun scrapeImagesFromUrl(url: String, limit: Int = 30): List<WallpaperItem>
+interface WebScraper {
+    suspend fun scrapePinterest(
+        query: String,
+        limit: Int = 30,
+        cursor: String? = null
+    ): ScrapePage
+
+    suspend fun scrapeImagesFromUrl(
+        url: String,
+        limit: Int = 30,
+        cursor: String? = null
+    ): ScrapePage
 }

--- a/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/WallpaperAdjustments.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/WallpaperAdjustments.kt
@@ -1,0 +1,54 @@
+package com.joshiminh.wallbase.util.wallpapers
+
+import android.graphics.Bitmap
+
+/**
+ * Encapsulates the user controlled edits applied to a wallpaper before it is
+ * downloaded or set on the device.
+ */
+data class WallpaperAdjustments(
+    val brightness: Float = 0f,
+    val filter: WallpaperFilter = WallpaperFilter.NONE,
+    val crop: WallpaperCrop = WallpaperCrop.AUTO,
+) {
+    val isIdentity: Boolean
+        get() =
+            brightness == 0f &&
+                filter == WallpaperFilter.NONE &&
+                crop == WallpaperCrop.AUTO
+}
+
+/**
+ * Describes high level filter effects that can be composed through a
+ * [android.graphics.ColorMatrix].
+ */
+enum class WallpaperFilter {
+    NONE,
+    GRAYSCALE,
+    SEPIA,
+}
+
+/**
+ * Simple crop presets that keep the workflow lightweight while offering a few
+ * common aspect ratios.
+ */
+enum class WallpaperCrop {
+    /**
+     * Crop to the device's current screen aspect ratio. This mirrors the
+     * previous behaviour of [WallpaperApplier] before editing was supported.
+     */
+    AUTO,
+
+    /** Preserve the original bitmap dimensions. */
+    ORIGINAL,
+
+    /** Produce a centered square crop. */
+    SQUARE,
+}
+
+/**
+ * Result returned by [WallpaperEditor] after applying [WallpaperAdjustments].
+ */
+data class EditedWallpaper(
+    val bitmap: Bitmap,
+)

--- a/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/WallpaperApplier.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/WallpaperApplier.kt
@@ -9,19 +9,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.drawable.BitmapDrawable
-import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
-import androidx.core.graphics.createBitmap
-import androidx.core.graphics.drawable.toBitmap
-import coil3.ImageLoader
-import coil3.asDrawable
-import coil3.request.ImageRequest
-import coil3.request.SuccessResult
-import coil3.request.allowHardware
 import com.joshiminh.wallbase.util.wallpapers.platform.PixelWallpaperHandler
 import com.joshiminh.wallbase.util.wallpapers.platform.SamsungWallpaperHandler
 import com.joshiminh.wallbase.util.wallpapers.platform.WallpaperPlatformHandler
@@ -29,14 +19,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import kotlin.math.abs
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.roundToInt
 
 class WallpaperApplier(
     val context: Context,
-    val imageLoader: ImageLoader = ImageLoader.Builder(context).build()
 ) {
 
     val platformHandlers: List<WallpaperPlatformHandler> = listOf(
@@ -45,10 +30,10 @@ class WallpaperApplier(
     )
 
     /**
-     * Applies the wallpaper from [imageUrl] to the given [target].
+     * Applies the provided [EditedWallpaper] to the selected [target].
      * Returns Result.success(Unit) on success, or Result.failure(e) on error.
      */
-    suspend fun apply(imageUrl: String, target: WallpaperTarget): Result<Unit> =
+    suspend fun apply(wallpaper: EditedWallpaper, target: WallpaperTarget): Result<Unit> =
         withContext(Dispatchers.IO) {
             // Runtime permission check to satisfy Lint and avoid SecurityException.
             val granted = ContextCompat.checkSelfPermission(
@@ -63,25 +48,23 @@ class WallpaperApplier(
             }
 
             runCatching {
-                val bitmap = loadWallpaperBitmap(imageUrl)
-                val cropped = cropForApplication(bitmap)
+                val bitmap = wallpaper.bitmap
 
                 val handled = platformHandlers
-                    .firstOrNull { handler -> handler.isEligible(context) && handler.applyWallpaper(context, cropped, target) }
+                    .firstOrNull { handler -> handler.isEligible(context) && handler.applyWallpaper(context, bitmap, target) }
 
                 if (handled == null) {
-                    applyWithWallpaperManager(cropped, target)
+                    applyWithWallpaperManager(bitmap, target)
                 }
             }
         }
 
     suspend fun createSystemPreview(
-        imageUrl: String,
+        wallpaper: EditedWallpaper,
         target: WallpaperTarget
     ): Result<PreviewData> = withContext(Dispatchers.IO) {
         runCatching {
-            val bitmap = loadWallpaperBitmap(imageUrl)
-            val file = createPreviewFile(bitmap)
+            val file = createPreviewFile(wallpaper.bitmap)
             val uri = FileProvider.getUriForFile(
                 context,
                 "${context.packageName}.fileprovider",
@@ -116,28 +99,6 @@ class WallpaperApplier(
 }
 
 data class PreviewData(val intent: Intent, val uri: Uri, val filePath: String)
-
-private fun Drawable.toSoftwareBitmap(): Bitmap {
-    val targetWidth = intrinsicWidth.takeIf { it > 0 } ?: 1
-    val targetHeight = intrinsicHeight.takeIf { it > 0 } ?: 1
-
-    if (this is BitmapDrawable) {
-        val source = bitmap
-        val cfg = source.config ?: Bitmap.Config.ARGB_8888
-        return if (source.config == Bitmap.Config.HARDWARE
-        ) {
-            // Convert from hardware to software-config bitmap
-            createBitmap(targetWidth, targetHeight).also { out ->
-                Canvas(out).drawBitmap(source, 0f, 0f, null)
-            }
-        } else {
-            // Ensure mutable
-            source.copy(cfg, /* isMutable = */ true)
-        }
-    }
-
-    return toBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
-}
 
 private fun WallpaperApplier.resolvePreviewIntent(uri: Uri): Intent {
     val handlerIntent = platformHandlers
@@ -199,55 +160,4 @@ private fun WallpaperApplier.createPreviewFile(bitmap: Bitmap): File {
         output.flush()
     }
     return file
-}
-
-private suspend fun WallpaperApplier.loadWallpaperBitmap(imageUrl: String): Bitmap {
-    val request = ImageRequest.Builder(context)
-        .data(imageUrl)
-        .allowHardware(false)
-        .build()
-
-    val result = imageLoader.execute(request)
-    val image = (result as? SuccessResult)?.image
-        ?: error("Unable to load wallpaper preview")
-    val drawable = image.asDrawable(context.resources)
-    return drawable.toSoftwareBitmap()
-}
-
-private fun WallpaperApplier.cropForApplication(bitmap: Bitmap): Bitmap {
-    val metrics = context.resources.displayMetrics
-    val targetWidth = max(metrics.widthPixels, 1)
-    val targetHeight = max(metrics.heightPixels, 1)
-
-    return bitmap.centerCropToAspectRatio(targetWidth, targetHeight)
-}
-
-private fun Bitmap.centerCropToAspectRatio(targetWidth: Int, targetHeight: Int): Bitmap {
-    if (targetWidth <= 0 || targetHeight <= 0) return this
-    val sourceWidth = width
-    val sourceHeight = height
-    if (sourceWidth <= 0 || sourceHeight <= 0) return this
-
-    val desiredRatio = targetWidth.toFloat() / targetHeight.toFloat()
-    val currentRatio = sourceWidth.toFloat() / sourceHeight.toFloat()
-    if (abs(currentRatio - desiredRatio) < 0.01f) return this
-
-    val cropWidth: Int
-    val cropHeight: Int
-    if (currentRatio > desiredRatio) {
-        cropHeight = sourceHeight
-        cropWidth = (sourceHeight * desiredRatio).roundToInt().coerceIn(1, sourceWidth)
-    } else {
-        cropWidth = sourceWidth
-        cropHeight = (sourceWidth / desiredRatio).roundToInt().coerceIn(1, sourceHeight)
-    }
-
-    val offsetX = ((sourceWidth - cropWidth) / 2f).roundToInt().coerceIn(0, max(sourceWidth - cropWidth, 0))
-    val offsetY = ((sourceHeight - cropHeight) / 2f).roundToInt().coerceIn(0, max(sourceHeight - cropHeight, 0))
-
-    val safeWidth = min(cropWidth, sourceWidth - offsetX)
-    val safeHeight = min(cropHeight, sourceHeight - offsetY)
-    if (safeWidth <= 0 || safeHeight <= 0) return this
-
-    return Bitmap.createBitmap(this, offsetX, offsetY, safeWidth, safeHeight)
 }

--- a/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/WallpaperEditor.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/WallpaperEditor.kt
@@ -1,0 +1,119 @@
+package com.joshiminh.wallbase.util.wallpapers
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
+import android.util.DisplayMetrics
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.toBitmap
+import coil3.ImageLoader
+import coil3.asDrawable
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.allowHardware
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Lightweight bitmap editing pipeline that mirrors the adjustments offered in
+ * [WallpaperDetailScreen]. It loads an image via Coil and applies the selected
+ * [WallpaperAdjustments] on a background thread before returning the
+ * [EditedWallpaper].
+ */
+class WallpaperEditor(
+    private val context: Context,
+    private val imageLoader: ImageLoader = ImageLoader.Builder(context).build(),
+) {
+
+    private val metrics: DisplayMetrics
+        get() = context.resources.displayMetrics
+
+    suspend fun loadOriginalBitmap(model: Any): Bitmap {
+        val request = ImageRequest.Builder(context)
+            .data(model)
+            .allowHardware(false)
+            .build()
+        val result = imageLoader.execute(request)
+        val drawable = (result as? SuccessResult)?.image
+            ?: error("Unable to load wallpaper for editing")
+        return drawable.asDrawable(context.resources).toBitmap().copy(Bitmap.Config.ARGB_8888, true)
+    }
+
+    fun applyAdjustments(source: Bitmap, adjustments: WallpaperAdjustments): EditedWallpaper {
+        var working = source
+        if (!working.isMutable) {
+            working = working.copy(working.config ?: Bitmap.Config.ARGB_8888, true)
+        }
+
+        val cropped = applyCrop(working, adjustments.crop)
+        val filtered = applyFilter(cropped, adjustments.filter)
+        val adjusted = applyBrightness(filtered, adjustments.brightness)
+        return EditedWallpaper(adjusted)
+    }
+
+    private fun applyCrop(bitmap: Bitmap, crop: WallpaperCrop): Bitmap {
+        val desiredRatio = when (crop) {
+            WallpaperCrop.AUTO -> metrics.widthPixels.toFloat() / metrics.heightPixels.toFloat()
+            WallpaperCrop.ORIGINAL -> return bitmap
+            WallpaperCrop.SQUARE -> 1f
+        }
+        if (desiredRatio <= 0f) return bitmap
+        val currentRatio = bitmap.width.toFloat() / bitmap.height.toFloat()
+        if (abs(currentRatio - desiredRatio) < 0.01f) return bitmap
+        val cropWidth: Int
+        val cropHeight: Int
+        if (currentRatio > desiredRatio) {
+            cropHeight = bitmap.height
+            cropWidth = (cropHeight * desiredRatio).roundToInt().coerceIn(1, bitmap.width)
+        } else {
+            cropWidth = bitmap.width
+            cropHeight = (cropWidth / desiredRatio).roundToInt().coerceIn(1, bitmap.height)
+        }
+        val offsetX = ((bitmap.width - cropWidth) / 2f).roundToInt().coerceIn(0, bitmap.width - cropWidth)
+        val offsetY = ((bitmap.height - cropHeight) / 2f).roundToInt().coerceIn(0, bitmap.height - cropHeight)
+        return Bitmap.createBitmap(bitmap, offsetX, offsetY, cropWidth, cropHeight)
+    }
+
+    private fun applyFilter(bitmap: Bitmap, filter: WallpaperFilter): Bitmap {
+        val matrix = when (filter) {
+            WallpaperFilter.NONE -> return bitmap
+            WallpaperFilter.GRAYSCALE -> ColorMatrix().apply { setSaturation(0f) }
+            WallpaperFilter.SEPIA -> ColorMatrix(
+                floatArrayOf(
+                    0.393f, 0.769f, 0.189f, 0f, 0f,
+                    0.349f, 0.686f, 0.168f, 0f, 0f,
+                    0.272f, 0.534f, 0.131f, 0f, 0f,
+                    0f, 0f, 0f, 1f, 0f,
+                ),
+            )
+        }
+        return bitmap.copyWithMatrix(matrix)
+    }
+
+    private fun applyBrightness(bitmap: Bitmap, brightness: Float): Bitmap {
+        if (brightness == 0f) return bitmap
+        val translate = (brightness * 255f).coerceIn(-255f, 255f)
+        val matrix = ColorMatrix(
+            floatArrayOf(
+                1f, 0f, 0f, 0f, translate,
+                0f, 1f, 0f, 0f, translate,
+                0f, 0f, 1f, 0f, translate,
+                0f, 0f, 0f, 1f, 0f,
+            ),
+        )
+        return bitmap.copyWithMatrix(matrix)
+    }
+
+    private fun Bitmap.copyWithMatrix(matrix: ColorMatrix): Bitmap {
+        val copy = createBitmap(width, height, config ?: Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(copy)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            colorFilter = ColorMatrixColorFilter(matrix)
+        }
+        canvas.drawBitmap(this, 0f, 0f, paint)
+        return copy
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/rotation/WallpaperRotationDefaults.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/rotation/WallpaperRotationDefaults.kt
@@ -1,0 +1,10 @@
+package com.joshiminh.wallbase.util.wallpapers.rotation
+
+import com.joshiminh.wallbase.util.wallpapers.WallpaperTarget
+
+object WallpaperRotationDefaults {
+    const val MIN_INTERVAL_MINUTES: Long = 15
+    const val DEFAULT_INTERVAL_MINUTES: Long = 60
+    val AVAILABLE_INTERVALS: List<Long> = listOf(15, 30, 60, 240, 1440)
+    val DEFAULT_TARGET: WallpaperTarget = WallpaperTarget.BOTH
+}

--- a/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/rotation/WallpaperRotationWorker.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/rotation/WallpaperRotationWorker.kt
@@ -1,0 +1,76 @@
+package com.joshiminh.wallbase.util.wallpapers.rotation
+
+import android.content.Context
+import android.net.Uri
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.joshiminh.wallbase.data.entity.wallpaper.WallpaperEntity
+import com.joshiminh.wallbase.util.network.ServiceLocator
+import com.joshiminh.wallbase.util.wallpapers.WallpaperAdjustments
+import com.joshiminh.wallbase.util.wallpapers.WallpaperApplier
+import com.joshiminh.wallbase.util.wallpapers.WallpaperEditor
+import com.joshiminh.wallbase.util.wallpapers.WallpaperTarget
+
+class WallpaperRotationWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        ServiceLocator.initialize(applicationContext)
+        val rotationRepository = ServiceLocator.rotationRepository
+        val schedule = rotationRepository.getActiveSchedule() ?: return Result.success()
+        val wallpapers = rotationRepository.fetchAlbumWallpapers(schedule.albumId)
+        if (wallpapers.isEmpty()) {
+            rotationRepository.disableSchedule(schedule.albumId)
+            return Result.success()
+        }
+        val next = selectNextWallpaper(wallpapers, schedule.lastWallpaperId) ?: return Result.success()
+        val model: Any = next.localUri?.takeIf { it.isNotBlank() }?.let { Uri.parse(it) } ?: next.imageUrl
+        val editor = WallpaperEditor(applicationContext)
+        val applier = WallpaperApplier(applicationContext)
+        val original = runCatching { editor.loadOriginalBitmap(model) }.getOrElse {
+            return Result.retry()
+        }
+        val processed = try {
+            editor.applyAdjustments(original, WallpaperAdjustments())
+        } finally {
+            if (!original.isRecycled) {
+                original.recycle()
+            }
+        }
+        val applyResult = applier.apply(processed, schedule.target)
+        processed.bitmap.recycle()
+        return applyResult.fold(
+            onSuccess = {
+                rotationRepository.recordApplication(schedule.id, next.id, System.currentTimeMillis())
+                Result.success()
+            },
+            onFailure = { throwable ->
+                if (throwable is SecurityException) {
+                    rotationRepository.disableSchedule(schedule.albumId)
+                    Result.success()
+                } else {
+                    Result.retry()
+                }
+            }
+        )
+    }
+
+    private fun selectNextWallpaper(
+        wallpapers: List<WallpaperEntity>,
+        lastId: Long?
+    ): WallpaperEntity? {
+        if (wallpapers.isEmpty()) return null
+        if (lastId == null) return wallpapers.first()
+        val index = wallpapers.indexOfFirst { it.id == lastId }
+        if (index == -1) return wallpapers.first()
+        val nextIndex = if (index == wallpapers.lastIndex) 0 else index + 1
+        return wallpapers.getOrNull(nextIndex)
+    }
+
+    companion object {
+        const val PERIODIC_WORK_NAME = "wallpaper_rotation_periodic"
+        const val ONE_TIME_WORK_NAME = "wallpaper_rotation_once"
+    }
+}


### PR DESCRIPTION
## Summary
- Recognize Wallhaven, Danbooru, Unsplash, and AlphaCoders URLs when adding sources and persist metadata for them.
- Integrate Wallhaven, Danbooru, and Unsplash APIs with paging plus fallback scrapes for AlphaCoders, and wire new Retrofit clients.
- Replace the Add from URL blurb with a supported-sources info dialog and include the new providers in source management UI.
- Reduce padding within SourceBrowseScreen to keep the browse layout compact.

## Testing
- ./gradlew lint *(fails: missing Android SDK / incompatible KSP version in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2be646ffc83309b4aea78bf658878