### PR TITLE
Thread settings callbacks through WallBaseApp

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
@@ -132,7 +132,11 @@ class MainActivity : ComponentActivity() {
                     onSettingsMessageShown = settingsViewModel::consumeMessage,
                     // NEW: thread these in instead of touching sourcesViewModel inside WallBaseApp
                     onAddDriveFolder = sourcesViewModel::addGoogleDriveFolder,
-                    onAddPhotosAlbum = sourcesViewModel::addGooglePhotosAlbum
+                    onAddPhotosAlbum = sourcesViewModel::addGooglePhotosAlbum,
+                    onToggleAutoDownload = settingsViewModel::setAutoDownload,
+                    onUpdateStorageLimit = settingsViewModel::setStorageLimit,
+                    onClearPreviewCache = settingsViewModel::clearPreviewCache,
+                    onClearOriginals = settingsViewModel::clearOriginalDownloads
                 )
             }
         }
@@ -195,7 +199,11 @@ fun WallBaseApp(
     onSettingsMessageShown: () -> Unit,
     // NEW: passed down from Activity
     onAddDriveFolder: (DriveFolder) -> Unit,
-    onAddPhotosAlbum: (GooglePhotosAlbum) -> Unit
+    onAddPhotosAlbum: (GooglePhotosAlbum) -> Unit,
+    onToggleAutoDownload: (Boolean) -> Unit,
+    onUpdateStorageLimit: (Long) -> Unit,
+    onClearPreviewCache: () -> Unit,
+    onClearOriginals: () -> Unit
 ) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -472,10 +480,10 @@ fun WallBaseApp(
                     onExportBackup = onExportBackup,
                     onImportBackup = onImportBackup,
                     onMessageShown = onSettingsMessageShown,
-                    onToggleAutoDownload = settingsViewModel::setAutoDownload,
-                    onUpdateStorageLimit = settingsViewModel::setStorageLimit,
-                    onClearPreviewCache = settingsViewModel::clearPreviewCache,
-                    onClearOriginals = settingsViewModel::clearOriginalDownloads
+                    onToggleAutoDownload = onToggleAutoDownload,
+                    onUpdateStorageLimit = onUpdateStorageLimit,
+                    onClearPreviewCache = onClearPreviewCache,
+                    onClearOriginals = onClearOriginals
                 )
             }
         }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
@@ -285,6 +285,8 @@ private fun AlbumDetailScreen(
 ) {
     val hasQuery = isSearching && searchQuery.isNotBlank()
     var rotationExpanded by rememberSaveable { mutableStateOf(false) }
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     LaunchedEffect(state.rotation.isConfigured) {
         if (!state.rotation.isConfigured) {

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -33,8 +33,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext


### PR DESCRIPTION
## Summary
- pass the settings-related callbacks into `WallBaseApp` from `MainActivity`
- forward those callbacks to `SettingsScreen` so the composable no longer references the activity view model directly

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found; bundled KSP version too old for Kotlin 2.2.10)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b2791bdc8330b1ee2f3007f14ea4