### PR TITLE
Fix compilation errors with updated dependencies

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/WallBaseApp.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/WallBaseApp.kt
@@ -6,6 +6,7 @@ import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
 import com.joshiminh.wallbase.util.network.ServiceLocator
 import java.io.File
+import okio.Path.Companion.toPath
 
 class WallBaseApp : Application() {
     override fun onCreate() {
@@ -15,11 +16,10 @@ class WallBaseApp : Application() {
             ImageLoader.Builder(context)
                 .diskCache {
                     DiskCache.Builder()
-                        .directory(File(context.cacheDir, "coil_previews"))
+                        .directory(File(context.cacheDir, "coil_previews").absolutePath.toPath())
                         .maxSizeBytes(50L * 1024 * 1024)
                         .build()
                 }
-                .respectCacheHeaders(false)
                 .build()
         }
     }

--- a/app/src/main/java/com/joshiminh/wallbase/data/repository/WallpaperRotationRepository.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/repository/WallpaperRotationRepository.kt
@@ -102,7 +102,7 @@ class WallpaperRotationRepository(
 
     suspend fun triggerRotationNow() {
         val request = OneTimeWorkRequestBuilder<WallpaperRotationWorker>()
-            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORKER)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
         workManager.enqueueUniqueWork(
             WallpaperRotationWorker.ONE_TIME_WORK_NAME,


### PR DESCRIPTION
## Summary
- update the Coil disk cache configuration to use okio paths compatible with Coil 3
- adjust wallpaper rotation worker to use the current OutOfQuotaPolicy constant
- return a Boolean from ensureEditorLoaded to avoid invalid use of the not operator

## Testing
- `./gradlew app:compileDebugKotlin` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c209083c833098a029a8d9771f72