### PR TITLE
Remove album list layout and stabilize browse screen

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/data/repository/SettingsRepository.kt
@@ -116,20 +116,19 @@ val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(na
 
 enum class AlbumLayout {
     GRID,
-    CARD_LIST,
-    LIST;
+    CARD_LIST;
 
     val storageValue: String
         get() = when (this) {
             GRID -> "grid"
             CARD_LIST -> "card_list"
-            LIST -> "list"
         }
 
     companion object {
         fun fromStorage(value: String?): AlbumLayout = when (value) {
             "grid" -> GRID
-            "list" -> LIST
+            // Previously saved "list" values now fall back to the card list layout.
+            "list" -> CARD_LIST
             else -> CARD_LIST
         }
     }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
@@ -348,49 +348,6 @@ private fun AlbumDetailScreen(
                             label = { Text("Removing downloads…") }
                         )
                     }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Surface(
-                        onClick = { showRotationDialog = true },
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = MaterialTheme.shapes.medium,
-                        tonalElevation = 2.dp
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
-                            verticalArrangement = Arrangement.spacedBy(12.dp)
-                        ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = "Scheduled rotation",
-                                        style = MaterialTheme.typography.titleMedium
-                                    )
-                                    Text(
-                                        text = rotationSummary(state.rotation, canConfigureRotation),
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                                Icon(
-                                    imageVector = Icons.Outlined.Schedule,
-                                    contentDescription = null
-                                )
-                            }
-                            val lastApplied = state.rotation.lastAppliedAt?.let { timestamp ->
-                                DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
-                                    .format(Date(timestamp))
-                            }
-                            if (lastApplied != null) {
-                                Text(
-                                    text = "Last rotated $lastApplied",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
-                        }
-                    }
                     Spacer(modifier = Modifier.height(12.dp))
                     if (wallpapers.isEmpty()) {
                         val message = when {

--- a/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
@@ -723,18 +723,6 @@ private fun AlbumList(
                 }
             }
         }
-
-        AlbumLayout.LIST -> {
-            LazyColumn(
-                modifier = modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(albums, key = AlbumItem::id) { album ->
-                    AlbumListRow(album = album, onClick = { onAlbumClick(album) })
-                }
-            }
-        }
     }
 }
 
@@ -776,39 +764,6 @@ private fun AlbumCard(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun AlbumListRow(
-    album: AlbumItem,
-    onClick: () -> Unit
-) {
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(14.dp),
-        tonalElevation = 0.dp,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        ListItem(
-            headlineContent = {
-                Text(
-                    text = album.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            },
-            supportingContent = {
-                Text(
-                    text = "${album.wallpaperCount} wallpapers",
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            },
-            colors = ListItemDefaults.colors(
-                containerColor = MaterialTheme.colorScheme.surface
-            )
-        )
     }
 }
 

--- a/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SourceBrowseScreen.kt
@@ -328,58 +328,62 @@ private fun SourceBrowseScreen(
             }
             Spacer(modifier = Modifier.height(4.dp))
 
-            PullToRefreshBox(
-                isRefreshing = state.isRefreshing,
-                onRefresh = onRefresh,
+            Box(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
             ) {
-                when {
-                    state.isLoading -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            CircularProgressIndicator()
-                        }
-                    }
-
-                    state.wallpapers.isEmpty() -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            if (state.errorMessage != null) {
-                                ErrorMessage(message = state.errorMessage, onRetry = onRefresh)
-                            } else {
-                                Text(
-                                    text = "No wallpapers found.",
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
+                PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = onRefresh,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    when {
+                        state.isLoading -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator()
                             }
                         }
-                    }
 
-                    else -> {
-                        WallpaperGrid(
-                            wallpapers = state.wallpapers,
-                            onWallpaperSelected = onWallpaperClick,
-                            onLongPress = onWallpaperLongPress,
-                            selectedIds = state.selectedIds,
-                            selectionMode = state.isSelectionMode,
-                            savedWallpaperKeys = state.savedWallpaperKeys,
-                            savedRemoteIdsByProvider = state.savedRemoteIdsByProvider,
-                            savedImageUrls = state.savedImageUrls,
-                            onLoadMore = onLoadMore.takeIf { state.canLoadMore },
-                            isLoadingMore = state.isAppending,
-                            canLoadMore = state.canLoadMore,
-                            modifier = Modifier.fillMaxSize(),
-                            columns = state.wallpaperGridColumns,
-                            layout = state.wallpaperLayout,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope
-                        )
+                        state.wallpapers.isEmpty() -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                if (state.errorMessage != null) {
+                                    ErrorMessage(message = state.errorMessage, onRetry = onRefresh)
+                                } else {
+                                    Text(
+                                        text = "No wallpapers found.",
+                                        style = MaterialTheme.typography.bodyLarge
+                                    )
+                                }
+                            }
+                        }
+
+                        else -> {
+                            WallpaperGrid(
+                                wallpapers = state.wallpapers,
+                                onWallpaperSelected = onWallpaperClick,
+                                onLongPress = onWallpaperLongPress,
+                                selectedIds = state.selectedIds,
+                                selectionMode = state.isSelectionMode,
+                                savedWallpaperKeys = state.savedWallpaperKeys,
+                                savedRemoteIdsByProvider = state.savedRemoteIdsByProvider,
+                                savedImageUrls = state.savedImageUrls,
+                                onLoadMore = onLoadMore.takeIf { state.canLoadMore },
+                                isLoadingMore = state.isAppending,
+                                canLoadMore = state.canLoadMore,
+                                modifier = Modifier.fillMaxSize(),
+                                columns = state.wallpaperGridColumns,
+                                layout = state.wallpaperLayout,
+                                sharedTransitionScope = sharedTransitionScope,
+                                animatedVisibilityScope = animatedVisibilityScope
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/LayoutSelectors.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/LayoutSelectors.kt
@@ -1,19 +1,35 @@
 package com.joshiminh.wallbase.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.GridView
+import androidx.compose.material.icons.outlined.ViewAgenda
+import androidx.compose.material.icons.outlined.ViewQuilt
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.joshiminh.wallbase.data.repository.AlbumLayout
 import com.joshiminh.wallbase.data.repository.WallpaperLayout
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun GridColumnPicker(
     label: String,
@@ -24,22 +40,31 @@ fun GridColumnPicker(
     enabled: Boolean = true
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Text(text = label, style = MaterialTheme.typography.labelLarge)
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            val options = range.toList()
-            options.forEachIndexed { index, count ->
-                SegmentedButton(
-                    selected = selectedColumns == count,
-                    onClick = { onColumnsSelected(count) },
-                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            range.forEach { count ->
+                val selected = selectedColumns == count
+                FilterChip(
+                    selected = selected,
+                    onClick = { if (enabled) onColumnsSelected(count) },
                     enabled = enabled,
-                    label = { Text(text = count.toString()) }
+                    label = {
+                        val suffix = if (count == 1) "column" else "columns"
+                        Text(text = "$count $suffix")
+                    },
+                    leadingIcon = if (selected) {
+                        { Icon(imageVector = Icons.Outlined.Check, contentDescription = null) }
+                    } else null
                 )
             }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun WallpaperLayoutPicker(
     label: String,
@@ -48,28 +73,30 @@ fun WallpaperLayoutPicker(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Text(text = label, style = MaterialTheme.typography.labelLarge)
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            val options = WallpaperLayout.values()
-            options.forEachIndexed { index, layout ->
-                SegmentedButton(
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            WallpaperLayout.values().forEach { layout ->
+                val (title, description, icon) = when (layout) {
+                    WallpaperLayout.GRID -> Triple("Grid", "Balanced rows", Icons.Outlined.GridView)
+                    WallpaperLayout.JUSTIFIED -> Triple("Justified", "Adaptive collage", Icons.Outlined.ViewQuilt)
+                    WallpaperLayout.LIST -> Triple("List", "Large previews", Icons.Outlined.ViewAgenda)
+                }
+                LayoutChoiceCard(
+                    title = title,
+                    description = description,
                     selected = selectedLayout == layout,
                     onClick = { onLayoutSelected(layout) },
-                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
-                    label = {
-                        val text = when (layout) {
-                            WallpaperLayout.GRID -> "Grid"
-                            WallpaperLayout.JUSTIFIED -> "Justified"
-                            WallpaperLayout.LIST -> "List"
-                        }
-                        Text(text = text)
-                    }
+                    icon = icon
                 )
             }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun AlbumLayoutPicker(
     label: String,
@@ -78,24 +105,75 @@ fun AlbumLayoutPicker(
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Text(text = label, style = MaterialTheme.typography.labelLarge)
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            val options = AlbumLayout.values()
-            options.forEachIndexed { index, layout ->
-                SegmentedButton(
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            AlbumLayout.values().forEach { layout ->
+                val (title, description, icon) = when (layout) {
+                    AlbumLayout.GRID -> Triple("Grid", "Compact tiles", Icons.Outlined.GridView)
+                    AlbumLayout.CARD_LIST -> Triple("Card list", "Spacious previews", Icons.Outlined.ViewAgenda)
+                }
+                LayoutChoiceCard(
+                    title = title,
+                    description = description,
                     selected = selectedLayout == layout,
                     onClick = { onLayoutSelected(layout) },
-                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
-                    label = {
-                        val text = when (layout) {
-                            AlbumLayout.GRID -> "Grid"
-                            AlbumLayout.CARD_LIST -> "Cards"
-                            AlbumLayout.LIST -> "List"
-                        }
-                        Text(text = text)
-                    }
+                    icon = icon
                 )
             }
         }
     }
+}
+
+@Composable
+private fun LayoutChoiceCard(
+    title: String,
+    description: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: ImageVector
+) {
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.widthIn(min = 160.dp),
+        shape = RoundedCornerShape(18.dp),
+        tonalElevation = if (selected) 8.dp else 0.dp,
+        color = if (selected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+        },
+        contentColor = if (selected) {
+            MaterialTheme.colorScheme.onSecondaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 14.dp)
+                .widthIn(min = 160.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(imageVector = icon, contentDescription = null)
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(text = title, style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            AnimatedVisibility(visible = selected) {
+                Icon(imageVector = Icons.Outlined.CheckCircle, contentDescription = null)
+            }
+        }
+    }
+    Spacer(modifier = Modifier.height(4.dp))
 }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/SortBottomSheet.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/SortBottomSheet.kt
@@ -1,6 +1,9 @@
 package com.joshiminh.wallbase.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -8,23 +11,24 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Sort
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.joshiminh.wallbase.ui.sort.SortDirection
 import com.joshiminh.wallbase.ui.sort.SortField
@@ -55,10 +59,21 @@ fun SortBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = "Choose how items are ordered",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
             availableFields.forEach { field ->
                 SortFieldRow(
                     field = field,
@@ -80,10 +95,9 @@ fun SortBottomSheet(
             }
             additionalContent?.let { content ->
                 Divider()
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(12.dp))
                 content()
             }
-            Spacer(modifier = Modifier.height(8.dp))
         }
     }
 }
@@ -97,35 +111,86 @@ private fun SortFieldRow(
 ) {
     Surface(
         onClick = onClick,
-        shape = RoundedCornerShape(14.dp),
-        tonalElevation = if (selected) 4.dp else 0.dp
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        tonalElevation = if (selected) 10.dp else 0.dp,
+        color = if (selected) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
+        }
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+                .animateContentSize(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(18.dp)
         ) {
-            RadioButton(selected = selected, onClick = null)
-            Spacer(modifier = Modifier.width(12.dp))
-            Text(
-                text = field.displayName,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.weight(1f)
-            )
-            direction?.let { dir ->
-                val icon = if (dir == SortDirection.Ascending) {
-                    Icons.Outlined.ArrowUpward
-                } else {
-                    Icons.Outlined.ArrowDownward
+            Box(
+                modifier = Modifier,
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    shape = CircleShape,
+                    color = if (selected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Sort,
+                        contentDescription = null,
+                        modifier = Modifier.padding(10.dp)
+                    )
                 }
-                val description = if (dir == SortDirection.Ascending) {
-                    "Ascending"
-                } else {
-                    "Descending"
-                }
-                Icon(imageVector = icon, contentDescription = description)
             }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = field.displayName,
+                    style = MaterialTheme.typography.titleSmall
+                )
+                AnimatedVisibility(visible = selected) {
+                    Text(
+                        text = "Tap to toggle direction",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+            AnimatedVisibility(visible = direction != null) {
+                direction?.let { dir ->
+                    DirectionBadge(direction = dir)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DirectionBadge(direction: SortDirection) {
+    val (icon, label) = if (direction == SortDirection.Ascending) {
+        Icons.Outlined.ArrowUpward to "Ascending"
+    } else {
+        Icons.Outlined.ArrowDownward to "Descending"
+    }
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Icon(imageVector = icon, contentDescription = label)
+            Text(text = label, style = MaterialTheme.typography.labelLarge)
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the legacy album list layout option and fall back to the card layout for stored preferences
- simplify the library album list to only render grid and card layouts
- wrap the source browse pull-to-refresh in a weighted box so it no longer crashes during compose layout
- drop the duplicate scheduled-rotation card from the album detail screen, leaving the floating action button
- refresh the sort bottom sheet and layout pickers with richer cards, icons, and chips

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK location not configured; build also reports bundled KSP is too old for Kotlin 2.2.10)*

------
https://chatgpt.com/codex/tasks/task_e_68d50a0f809c8330a5cba018aac8863f