### PR TITLE
Refine wallpaper detail layout and settings cards

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/SettingsScreen.kt
@@ -17,13 +17,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
@@ -40,10 +44,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
 import com.joshiminh.wallbase.ui.viewmodel.SettingsViewModel
 import kotlin.math.roundToInt
 
@@ -426,46 +434,26 @@ fun SettingsScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    SettingsCard {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(12.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                Text(
-                                    text = "WallBase",
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                                Text(
-                                    text = "Explore the project or support future development.",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
+                    SettingsLinkCard(
+                        title = "GitHub",
+                        description = "Explore the project repository.",
+                        buttonText = "Open",
+                        iconUrl = "https://github.githubassets.com/favicons/favicon.png",
+                        onClick = { uriHandler.openUri("https://github.com/JoshiMinh/WallBase") }
+                    )
 
-                            Column(
-                                horizontalAlignment = Alignment.End,
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                TextButton(onClick = {
-                                    uriHandler.openUri("https://github.com/JoshiMinh/WallBase")
-                                }) {
-                                    Text(text = "GitHub")
-                                }
-                                TextButton(onClick = {
-                                    uriHandler.openUri("https://ko-fi.com/joshiminh")
-                                }) {
-                                    Text(text = "Ko-fi")
-                                }
-                            }
-                        }
-                    }
+                    SettingsLinkCard(
+                        title = "Ko-fi",
+                        description = "Support future development.",
+                        buttonText = "Support",
+                        iconUrl = "https://ko-fi.com/favicon.ico",
+                        onClick = { uriHandler.openUri("https://ko-fi.com/joshiminh") },
+                        colors = CardDefaults.cardColors(
+                            containerColor = Color(0xFFFF5E5B),
+                            contentColor = Color.White
+                        ),
+                        buttonColors = ButtonDefaults.textButtonColors(contentColor = Color.White)
+                    )
                 }
             }
         }
@@ -481,15 +469,69 @@ private fun SettingsSection(
 }
 
 @Composable
-private fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
+private fun SettingsCard(
+    modifier: Modifier = Modifier,
+    colors: CardColors = CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceVariant
+    ),
+    content: @Composable ColumnScope.() -> Unit
+) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
-        ),
+        colors = colors,
         content = content
     )
+}
+
+@Composable
+private fun SettingsLinkCard(
+    title: String,
+    description: String,
+    buttonText: String,
+    iconUrl: String,
+    onClick: () -> Unit,
+    colors: CardColors = CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceVariant
+    ),
+    buttonColors: ButtonColors = ButtonDefaults.textButtonColors()
+) {
+    SettingsCard(colors = colors) {
+        val contentColor = LocalContentColor.current
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = iconUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.8f)
+                )
+            }
+            TextButton(onClick = onClick, colors = buttonColors) {
+                Text(text = buttonText)
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperDetailScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -212,37 +214,39 @@ private fun WallpaperDetailScreen(
         canAddToLibrary
     }
 
+    val scrollState = rememberScrollState()
+
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         contentWindowInsets = WindowInsets(left = 0.dp, top = 0.dp, right = 0.dp, bottom = 0.dp)
     ) { innerPadding ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(16.dp)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Surface(
-                modifier = Modifier.fillMaxSize(),
-                shape = RoundedCornerShape(32.dp),
-                color = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp))
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(24.dp),
+                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(6.dp)
                 ) {
-                    val previewBitmap = uiState.editedPreview
-                    val previewShape = RoundedCornerShape(32.dp)
-                    val previewModifier = sharedModifier.then(
-                        Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(aspectRatio)
-                    )
                     Box(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)),
                         contentAlignment = Alignment.Center
                     ) {
+                        val previewBitmap = uiState.editedPreview
+                        val previewShape = RoundedCornerShape(24.dp)
+                        val previewModifier = sharedModifier.then(
+                            Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(aspectRatio)
+                        )
                         Box(
                             modifier = previewModifier,
                             contentAlignment = Alignment.Center
@@ -281,223 +285,214 @@ private fun WallpaperDetailScreen(
                         }
                     }
                 }
-            }
 
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(24.dp),
-                shape = CircleShape,
-                tonalElevation = 4.dp,
-                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
-            ) {
-                IconButton(onClick = onNavigateBack) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back"
-                    )
-                }
-            }
-
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(24.dp),
-                shape = CircleShape,
-                tonalElevation = 4.dp,
-                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
-            ) {
-                IconButton(onClick = onEditWallpaper) {
-                    Icon(
-                        imageVector = Icons.Outlined.Edit,
-                        contentDescription = "Edit wallpaper"
-                    )
-                }
-            }
-
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(start = 24.dp, end = if (showLibraryAction) 96.dp else 24.dp, bottom = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                if (statusMessages.isNotEmpty()) {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        statusMessages.forEach { status ->
-                            AssistChip(onClick = {}, enabled = false, label = { Text(text = status) })
-                        }
-                    }
-                }
-
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = wallpaper.title.ifBlank { "Untitled wallpaper" },
-                            style = MaterialTheme.typography.titleLarge,
-                            modifier = Modifier.weight(1f),
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(8.dp),
+                    shape = CircleShape,
+                    tonalElevation = 4.dp,
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
+                ) {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
                         )
-                        IconButton(onClick = { uriHandler.openUri(wallpaper.sourceUrl) }) {
-                            Icon(
-                                imageVector = Icons.Outlined.OpenInNew,
-                                contentDescription = "Open original"
-                            )
+                    }
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp),
+                    shape = CircleShape,
+                    tonalElevation = 4.dp,
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
+                ) {
+                    IconButton(onClick = onEditWallpaper) {
+                        Icon(
+                            imageVector = Icons.Outlined.Edit,
+                            contentDescription = "Edit wallpaper"
+                        )
+                    }
+                }
+
+                if (showLibraryAction) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(8.dp)
+                            .size(56.dp)
+                            .combinedClickable(
+                                enabled = !libraryBusy,
+                                onClick = {
+                                    if (!libraryBusy && canToggleLibrary) {
+                                        if (uiState.isInLibrary) {
+                                            onRemoveFromLibrary()
+                                        } else {
+                                            onAddToLibrary()
+                                        }
+                                    }
+                                },
+                                onLongClick = {
+                                    if (!libraryBusy) {
+                                        showAlbumPicker = true
+                                    }
+                                }
+                            ),
+                        shape = CircleShape,
+                        tonalElevation = 6.dp,
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            when {
+                                libraryBusy -> {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier
+                                            .width(24.dp)
+                                            .height(24.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                }
+
+                                uiState.isInLibrary -> {
+                                    Icon(imageVector = Icons.Outlined.TaskAlt, contentDescription = "Remove from library")
+                                }
+
+                                else -> {
+                                    Icon(imageVector = Icons.Filled.Add, contentDescription = "Add to library")
+                                }
+                            }
                         }
                     }
+                }
+            }
+
+            if (statusMessages.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    statusMessages.forEach { status ->
+                        AssistChip(onClick = {}, enabled = false, label = { Text(text = status) })
+                    }
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = wallpaper.sourceName?.takeIf { it.isNotBlank() } ?: "Unknown source",
+                        text = wallpaper.title.ifBlank { "Untitled wallpaper" },
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    IconButton(onClick = { uriHandler.openUri(wallpaper.sourceUrl) }) {
+                        Icon(
+                            imageVector = Icons.Outlined.OpenInNew,
+                            contentDescription = "Open original"
+                        )
+                    }
+                }
+                Text(
+                    text = wallpaper.sourceName?.takeIf { it.isNotBlank() } ?: "Unknown source",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (!uiState.hasWallpaperPermission) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        text = "Allow WallBase to open the system wallpaper preview so you can confirm the image.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                }
-
-                if (!uiState.hasWallpaperPermission) {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text(
-                            text = "Allow WallBase to open the system wallpaper preview so you can confirm the image.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        TextButton(onClick = onRequestPermission) {
-                            Text(text = "Grant wallpaper access")
-                        }
+                    TextButton(onClick = onRequestPermission) {
+                        Text(text = "Grant wallpaper access")
                     }
                 }
+            }
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                val downloadEnabled = when {
+                    uiState.isDownloaded -> !uiState.isRemovingDownload
+                    else -> canDownload && !uiState.isDownloading
+                }
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        if (uiState.isDownloaded) {
+                            onRequestRemoveDownload()
+                        } else {
+                            onDownload()
+                        }
+                    },
+                    enabled = downloadEnabled
                 ) {
-                    val downloadEnabled = when {
-                        uiState.isDownloaded -> !uiState.isRemovingDownload
-                        else -> canDownload && !uiState.isDownloading
-                    }
-                    Button(
-                        modifier = Modifier.weight(1f),
-                        onClick = {
-                            if (uiState.isDownloaded) {
-                                onRequestRemoveDownload()
-                            } else {
-                                onDownload()
-                            }
-                        },
-                        enabled = downloadEnabled
-                    ) {
-                        when {
-                            uiState.isRemovingDownload -> {
-                                CircularProgressIndicator(
-                                    modifier = Modifier
-                                        .width(18.dp)
-                                        .height(18.dp),
-                                    strokeWidth = 2.dp
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(text = "Removing…")
-                            }
-
-                            uiState.isDownloading -> {
-                                CircularProgressIndicator(
-                                    modifier = Modifier
-                                        .width(18.dp)
-                                        .height(18.dp),
-                                    strokeWidth = 2.dp
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(text = "Downloading…")
-                            }
-
-                            uiState.isDownloaded -> {
-                                Icon(imageVector = Icons.Outlined.TaskAlt, contentDescription = null)
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(text = "Downloaded")
-                            }
-
-                            else -> {
-                                Icon(imageVector = Icons.Outlined.CloudDownload, contentDescription = null)
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(text = "Download")
-                            }
-                        }
-                    }
-
-                    Button(
-                        modifier = Modifier.weight(1f),
-                        onClick = { showTargetDialog = true },
-                        enabled = uiState.hasWallpaperPermission && !uiState.isApplying
-                    ) {
-                        if (uiState.isApplying) {
+                    when {
+                        uiState.isRemovingDownload -> {
                             CircularProgressIndicator(
                                 modifier = Modifier
                                     .width(18.dp)
                                     .height(18.dp),
                                 strokeWidth = 2.dp
                             )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(text = "Applying…")
-                        } else {
-                            Icon(imageVector = Icons.Outlined.Wallpaper, contentDescription = null)
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(text = "Set")
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(text = "Removing…")
+                        }
+
+                        uiState.isDownloading -> {
+                            CircularProgressIndicator(
+                                modifier = Modifier
+                                    .width(18.dp)
+                                    .height(18.dp),
+                                strokeWidth = 2.dp
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(text = "Downloading…")
+                        }
+
+                        uiState.isDownloaded -> {
+                            Icon(imageVector = Icons.Outlined.TaskAlt, contentDescription = null)
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(text = "Downloaded")
+                        }
+
+                        else -> {
+                            Icon(imageVector = Icons.Outlined.CloudDownload, contentDescription = null)
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(text = "Download")
                         }
                     }
                 }
-            }
 
-            if (showLibraryAction) {
-                Surface(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(24.dp)
-                        .size(64.dp)
-                        .combinedClickable(
-                            enabled = !libraryBusy,
-                            onClick = {
-                                if (!libraryBusy && canToggleLibrary) {
-                                    if (uiState.isInLibrary) {
-                                        onRemoveFromLibrary()
-                                    } else {
-                                        onAddToLibrary()
-                                    }
-                                }
-                            },
-                            onLongClick = {
-                                if (!libraryBusy) {
-                                    showAlbumPicker = true
-                                }
-                            }
-                        ),
-                    shape = CircleShape,
-                    tonalElevation = 6.dp,
-                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = { showTargetDialog = true },
+                    enabled = uiState.hasWallpaperPermission && !uiState.isApplying
                 ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        when {
-                            libraryBusy -> {
-                                CircularProgressIndicator(
-                                    modifier = Modifier
-                                        .width(24.dp)
-                                        .height(24.dp),
-                                    strokeWidth = 2.dp
-                                )
-                            }
-
-                            uiState.isInLibrary -> {
-                                Icon(imageVector = Icons.Outlined.TaskAlt, contentDescription = "Remove from library")
-                            }
-
-                            else -> {
-                                Icon(imageVector = Icons.Default.Add, contentDescription = "Add to library")
-                            }
-                        }
+                    if (uiState.isApplying) {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .width(18.dp)
+                                .height(18.dp),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(text = "Applying…")
+                    } else {
+                        Icon(imageVector = Icons.Outlined.Wallpaper, contentDescription = null)
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(text = "Set wallpaper")
                     }
                 }
             }
         }
     }
-
     if (uiState.showRemoveDownloadConfirmation) {
         AlertDialog(
             onDismissRequest = {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ googleid = "1.1.1"                             # Sign in with Google on Credenti
 
 # Google APIs
 google-api-client-android = "2.8.1"            # Base client for Android :contentReference[oaicite:10]{index=10}
-google-drive = "v3-rev20250829-2.0.0"          # Drive REST client rev
 google-photos = "1.7.3"                        # Photos Library Java client :contentReference[oaicite:12]{index=12}
 
 # SAF helper
@@ -88,9 +87,8 @@ googleid = { module = "com.google.android.libraries.identity.googleid:googleid",
 material3 = { module = "androidx.compose.material3:material3" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version = "21.4.0" } # deprecated path; FYI :contentReference[oaicite:19]{index=19}
 
-# Google APIs (Drive + Photos)
+# Google APIs (Photos)
 google-api-client-android = { module = "com.google.api-client:google-api-client-android", version.ref = "google-api-client-android" }
-google-api-services-drive = { module = "com.google.apis:google-api-services-drive", version.ref = "google-drive" }
 google-photos-library-client = { module = "com.google.photos.library:google-photos-library-client", version.ref = "google-photos" }
 
 # SAF helper lib


### PR DESCRIPTION
## Summary
- restructure the wallpaper detail screen with minimal padding, buttons below the preview, and retained quick actions
- split the settings About section into dedicated GitHub and Ko-fi cards that use remote favicons and brand styling
- remove the unused Google Drive dependency entries from the version catalog

## Testing
- `./gradlew lintDebug` *(fails: SDK location not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d62ad597c48330bae9f18032964491