### PR TITLE
Move app lock overlay into Box scope

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/MainActivity.kt
@@ -167,17 +167,6 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-
-    if (settingsUiState.appLockEnabled && !isAppUnlocked) {
-        AppLockOverlay(
-            modifier = Modifier.fillMaxSize(),
-            onUnlock = {
-                if (pendingAppLockRequest == null && activeAppLockRequest == null) {
-                    pendingAppLockRequest = AppLockRequest.Unlock
-                }
-            }
-        )
-    }
 }
 
 /** Top-level routes for bottom navigation */
@@ -654,8 +643,17 @@ fun WallBaseApp(
                 )
             }
         }
+        if (settingsUiState.appLockEnabled && !isAppUnlocked) {
+            AppLockOverlay(
+                modifier = Modifier.fillMaxSize(),
+                onUnlock = {
+                    if (pendingAppLockRequest == null && activeAppLockRequest == null) {
+                        pendingAppLockRequest = AppLockRequest.Unlock
+                    }
+                }
+            )
+        }
     }
-}
 }
 
 private fun currentTitle(dest: NavDestination?): String = when {
@@ -724,4 +722,4 @@ private fun AppLockOverlay(
             }
         }
     }
-}}
+}


### PR DESCRIPTION
## Summary
- relocate the app lock overlay logic into the Box inside WallBaseApp so it stays within the composable tree

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daab7ffc8c8330981f15c7f237f89e