### PR TITLE
Refactor shared wallpaper transition modifier

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
@@ -619,8 +619,7 @@ private fun RotationScheduleBottomSheet(
                 if (minutes != rotationState.intervalMinutes && canConfigure && !rotationState.isUpdating) {
                     onSelectRotationInterval(minutes)
                 }
-                intervalValue = selectedIntervalUnit.displayValue(minute
-                        s)
+                intervalValue = selectedIntervalUnit.displayValue(minutes)
                 true
             }
         }

--- a/app/src/main/java/com/joshiminh/wallbase/ui/EditWallpaperScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/EditWallpaperScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperDetailScreen.kt
@@ -6,10 +6,8 @@ import android.Manifest
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.BoundsTransform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -26,6 +24,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -82,6 +81,7 @@ import com.joshiminh.wallbase.data.entity.album.AlbumItem
 import com.joshiminh.wallbase.data.entity.source.SourceKeys
 import com.joshiminh.wallbase.data.entity.wallpaper.WallpaperItem
 import com.joshiminh.wallbase.ui.components.WallpaperPreviewImage
+import com.joshiminh.wallbase.ui.components.sharedWallpaperTransitionModifier
 import com.joshiminh.wallbase.ui.viewmodel.WallpaperDetailViewModel
 import com.joshiminh.wallbase.util.wallpapers.WallpaperTarget
 
@@ -183,21 +183,11 @@ private fun WallpaperDetailScreen(
     var showTargetDialog by remember { mutableStateOf(false) }
     var showAlbumPicker by remember { mutableStateOf(false) }
     val aspectRatio = wallpaper.aspectRatio?.takeIf { it > 0f } ?: DEFAULT_DETAIL_ASPECT_RATIO
-    val sharedModifier =
-        if (sharedTransitionScope != null && animatedVisibilityScope != null) {
-            with(sharedTransitionScope) {
-                Modifier.sharedBounds(
-                    sharedContentState = rememberSharedContentState(key = wallpaper.transitionKey()),
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    // pick one:
-                    resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds(),
-                    // or: resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
-                    boundsTransform = BoundsTransform { _, _ -> tween(durationMillis = 350) }
-                )
-            }
-        } else {
-            Modifier
-        }
+    val sharedModifier = sharedWallpaperTransitionModifier(
+        wallpaper = wallpaper,
+        sharedTransitionScope = sharedTransitionScope,
+        animatedVisibilityScope = animatedVisibilityScope
+    )
     val statusMessages = remember(
         uiState.isDownloading,
         uiState.isRemovingDownload,

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/SharedTransitions.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/SharedTransitions.kt
@@ -1,0 +1,37 @@
+package com.joshiminh.wallbase.ui.components
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.rememberSharedContentState
+import androidx.compose.animation.sharedBounds
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.joshiminh.wallbase.data.entity.wallpaper.WallpaperItem
+
+private const val SHARED_TRANSITION_DURATION_MILLIS = 350
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun sharedWallpaperTransitionModifier(
+    wallpaper: WallpaperItem,
+    sharedTransitionScope: SharedTransitionScope?,
+    animatedVisibilityScope: AnimatedVisibilityScope?
+): Modifier {
+    if (sharedTransitionScope == null || animatedVisibilityScope == null) {
+        return Modifier
+    }
+
+    return with(sharedTransitionScope) {
+        Modifier.sharedBounds(
+            sharedContentState = rememberSharedContentState(key = wallpaper.transitionKey()),
+            animatedVisibilityScope = animatedVisibilityScope,
+            resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds(),
+            boundsTransform = BoundsTransform { _, _ ->
+                tween(durationMillis = SHARED_TRANSITION_DURATION_MILLIS)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/WallpaperGrid.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/WallpaperGrid.kt
@@ -2,10 +2,8 @@ package com.joshiminh.wallbase.ui.components
 
 import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.BoundsTransform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -21,6 +19,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -57,8 +56,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.joshiminh.wallbase.data.repository.WallpaperLayout
 import com.joshiminh.wallbase.data.entity.wallpaper.WallpaperItem
+import com.joshiminh.wallbase.data.repository.WallpaperLayout
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 private const val UNKNOWN_PROVIDER_KEY = ""
@@ -200,7 +199,7 @@ fun WallpaperGrid(
                         savedRemoteIdsByProvider = savedRemoteIdsByProvider,
                         savedImageUrls = savedImageUrls
                     )
-                    val sharedModifier = sharedModifierFor(
+                    val sharedModifier = sharedWallpaperTransitionModifier(
                         wallpaper = wallpaper,
                         sharedTransitionScope = sharedTransitionScope,
                         animatedVisibilityScope = animatedVisibilityScope
@@ -310,7 +309,7 @@ fun WallpaperGrid(
                                     savedRemoteIdsByProvider = savedRemoteIdsByProvider,
                                     savedImageUrls = savedImageUrls
                                 )
-                                val sharedModifier = sharedModifierFor(
+                                val sharedModifier = sharedWallpaperTransitionModifier(
                                     wallpaper = wallpaper,
                                     sharedTransitionScope = sharedTransitionScope,
                                     animatedVisibilityScope = animatedVisibilityScope
@@ -381,7 +380,7 @@ fun WallpaperGrid(
                         savedRemoteIdsByProvider = savedRemoteIdsByProvider,
                         savedImageUrls = savedImageUrls
                     )
-                    val sharedModifier = sharedModifierFor(
+                    val sharedModifier = sharedWallpaperTransitionModifier(
                         wallpaper = wallpaper,
                         sharedTransitionScope = sharedTransitionScope,
                         animatedVisibilityScope = animatedVisibilityScope
@@ -412,27 +411,6 @@ fun WallpaperGrid(
                 }
             }
         }
-    }
-}
-
-@SuppressLint("ModifierFactoryExtensionFunction")
-@OptIn(ExperimentalSharedTransitionApi::class)
-@Composable
-private fun sharedModifierFor(
-    wallpaper: WallpaperItem,
-    sharedTransitionScope: SharedTransitionScope?,
-    animatedVisibilityScope: AnimatedVisibilityScope?
-): Modifier {
-    if (sharedTransitionScope == null || animatedVisibilityScope == null) {
-        return Modifier
-    }
-    return with(sharedTransitionScope) {
-        Modifier.sharedBounds(
-            sharedContentState = rememberSharedContentState(key = wallpaper.transitionKey()),
-            animatedVisibilityScope = animatedVisibilityScope,
-            resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds(),
-            boundsTransform = BoundsTransform { _, _ -> tween(durationMillis = 350) }
-        )
     }
 }
 

--- a/app/src/main/java/com/joshiminh/wallbase/ui/components/WallpaperPreviewImage.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/components/WallpaperPreviewImage.kt
@@ -3,6 +3,7 @@ package com.joshiminh.wallbase.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## Summary
- extract a reusable sharedWallpaperTransitionModifier so shared elements configure their transitions consistently
- update the wallpaper detail and grid screens to use the helper and drop duplicate transition setup code
- add the missing shared transition imports needed for the shared element animations to compile cleanly

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db5ce9f4c48330bb78bccef8aea5ca