### PR TITLE
Fix CropOverlay Canvas invocation

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/AlbumDetailScreen.kt
@@ -404,7 +404,7 @@ private fun AlbumDetailScreen(
             !state.isRemovingDownloads &&
             !state.notFound
     val defaultFabContainerColor = FloatingActionButtonDefaults.containerColor
-    val defaultFabContentColor = FloatingActionButtonDefaults.contentColor()
+    val defaultFabContentColor = FloatingActionButtonDefaults.contentColor
     val disabledFabContainerColor = MaterialTheme.colorScheme.surfaceVariant
     val disabledFabContentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
 

--- a/app/src/main/java/com/joshiminh/wallbase/ui/EditWallpaperScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/EditWallpaperScreen.kt
@@ -515,7 +515,7 @@ private fun CropOverlay(
     handleRadius: Float,
     overlayColor: Color,
 ) {
-    Canvas(Canvas(Modifier.fillMaxSize())) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
         if (size.width <= 0f || size.height <= 0f) return@Canvas
         val left = crop.left.coerceIn(0f, 1f) * size.width
         val top = crop.top.coerceIn(0f, 1f) * size.height

--- a/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperDetailScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperDetailScreen.kt
@@ -241,7 +241,7 @@ private fun WallpaperDetailScreen(
                         val previewBitmap = uiState.editedPreview
                         val previewShape = RoundedCornerShape(24.dp)
                         val previewModifier = sharedModifier.then(
-                            comparator = Modifier
+                            Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(aspectRatio)
                         )


### PR DESCRIPTION
## Summary
- replace the nested Canvas call in CropOverlay with a single Canvas modifier invocation to resolve the overload mismatch
- fix the wallpaper detail preview modifier chaining by passing the modifier argument positionally to `Modifier.then`

## Testing
- ⚠️ `./gradlew :app:assembleDebug` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db7f9b7318833080f18af2937727f1