### PR TITLE
Add wallpaper floating action button to library

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/ui/EditWallpaperScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/EditWallpaperScreen.kt
@@ -596,13 +596,13 @@ private enum class CropHandle {
 
 @Composable
 private fun FlowingChipRow(content: @Composable RowScope.() -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState()),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        content = content
-    )
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            content = content
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/LibraryScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
@@ -443,11 +444,6 @@ fun LibraryScreen(
                         Icon(imageVector = Icons.Outlined.Search, contentDescription = "Search")
                     }
                 } else {
-                    if (selectedTab == 0) {
-                        IconButton(onClick = { showDirectAddDialog = true }) {
-                            Icon(imageVector = Icons.Outlined.Add, contentDescription = "Add wallpaper")
-                        }
-                    }
                     IconButton(onClick = { isSearchActive = true }) {
                         Icon(imageVector = Icons.Outlined.Search, contentDescription = "Search")
                     }
@@ -563,28 +559,36 @@ fun LibraryScreen(
         Scaffold(
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             floatingActionButton = {
-                if (selectedTab == 1) {
-                    val creating = uiState.isCreatingAlbum
-                    ExtendedFloatingActionButton(
-                        onClick = { if (!creating) showAlbumDialog = true },
-                        icon = {
-                            Icon(
-                                imageVector = Icons.Outlined.Add,
-                                contentDescription = "Add album"
+                when {
+                    selectedTab == 0 && !selectionMode -> {
+                        FloatingActionButton(onClick = { showDirectAddDialog = true }) {
+                            Icon(imageVector = Icons.Outlined.Add, contentDescription = "Add wallpaper")
+                        }
+                    }
+
+                    selectedTab == 1 -> {
+                        val creating = uiState.isCreatingAlbum
+                        ExtendedFloatingActionButton(
+                            onClick = { if (!creating) showAlbumDialog = true },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Add,
+                                    contentDescription = "Add album"
+                                )
+                            },
+                            text = { Text(text = "Add album") },
+                            expanded = true,
+                            modifier = Modifier.then(
+                                if (creating) {
+                                    Modifier
+                                        .alpha(0.6f)
+                                        .semantics { disabled() }
+                                } else {
+                                    Modifier
+                                }
                             )
-                        },
-                        text = { Text(text = "Add album") },
-                        expanded = true,
-                        modifier = Modifier.then(
-                            if (creating) {
-                                Modifier
-                                    .alpha(0.6f)
-                                    .semantics { disabled() }
-                            } else {
-                                Modifier
-                            }
                         )
-                    )
+                    }
                 }
             },
             contentWindowInsets = WindowInsets(left = 0.dp, top = 0.dp, right = 0.dp, bottom = 0.dp)

--- a/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/rotation/WallpaperRotationWorker.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/util/wallpapers/rotation/WallpaperRotationWorker.kt
@@ -3,6 +3,7 @@ package com.joshiminh.wallbase.util.wallpapers.rotation
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -117,7 +118,8 @@ class WallpaperRotationWorker(
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             ForegroundInfo(
                 NOTIFICATION_ID,
-                notification
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
             )
         } else {
             ForegroundInfo(NOTIFICATION_ID, notification)


### PR DESCRIPTION
## Summary
- add the foreground service type when starting the rotation worker on Android Q+
- move the add wallpaper action from the library top bar to a floating action button on the wallpaper tab

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc8e5a6d948330bb665a30f8d53046