### PR TITLE
Improve wallpaper editor layout and crop handling

### DIFF
--- a/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperEditScreen.kt
+++ b/app/src/main/java/com/joshiminh/wallbase/ui/WallpaperEditScreen.kt
@@ -1,0 +1,331 @@
+package com.joshiminh.wallbase.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.joshiminh.wallbase.ui.viewmodel.WallpaperDetailViewModel
+import com.joshiminh.wallbase.util.wallpapers.WallpaperAdjustments
+import com.joshiminh.wallbase.util.wallpapers.WallpaperCrop
+import com.joshiminh.wallbase.util.wallpapers.WallpaperCropSettings
+import com.joshiminh.wallbase.util.wallpapers.WallpaperFilter
+import kotlin.math.roundToInt
+
+@Composable
+fun WallpaperEditSection(
+    uiState: WallpaperDetailViewModel.WallpaperDetailUiState,
+    onUpdateBrightness: (Float) -> Unit,
+    onUpdateHue: (Float) -> Unit,
+    onUpdateFilter: (WallpaperFilter) -> Unit,
+    onUpdateCrop: (WallpaperCrop) -> Unit,
+    onResetAdjustments: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val adjustments = uiState.adjustments
+    val isProcessing = uiState.isProcessingEdits
+    val controlsEnabled = uiState.isEditorReady
+
+    Surface(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = "Adjustments", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = "Tune the wallpaper before applying it to your device.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (isProcessing) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                        Text(
+                            text = "Updating preview…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            AdjustmentSlider(
+                label = "Brightness",
+                value = adjustments.brightness,
+                valueRange = -0.5f..0.5f,
+                steps = 0,
+                enabled = controlsEnabled,
+                onValueChange = onUpdateBrightness,
+                formatter = { value -> "${(value / 0.5f * 100).roundToInt()}%" }
+            )
+
+            AdjustmentSlider(
+                label = "Hue",
+                value = adjustments.hue,
+                valueRange = -180f..180f,
+                steps = 0,
+                enabled = controlsEnabled,
+                onValueChange = onUpdateHue,
+                formatter = { value -> "${value.roundToInt()}°" }
+            )
+
+            FilterSelection(
+                selected = adjustments.filter,
+                enabled = controlsEnabled,
+                onFilterSelected = onUpdateFilter
+            )
+
+            CropSelection(
+                adjustments = adjustments,
+                enabled = controlsEnabled,
+                onUpdateCrop = onUpdateCrop
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(
+                    onClick = onResetAdjustments,
+                    enabled = controlsEnabled && !adjustments.isIdentity
+                ) {
+                    Text(text = "Reset adjustments")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdjustmentSlider(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    enabled: Boolean,
+    onValueChange: (Float) -> Unit,
+    formatter: (Float) -> String,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = label, style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = formatter(value),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+            steps = steps,
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FilterSelection(
+    selected: WallpaperFilter,
+    enabled: Boolean,
+    onFilterSelected: (WallpaperFilter) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(text = "Filter", style = MaterialTheme.typography.titleSmall)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            WallpaperFilter.values().forEach { filter ->
+                FilterChip(
+                    selected = selected == filter,
+                    onClick = { if (enabled) onFilterSelected(filter) },
+                    enabled = enabled,
+                    label = { Text(text = filter.displayName()) }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CropSelection(
+    adjustments: WallpaperAdjustments,
+    enabled: Boolean,
+    onUpdateCrop: (WallpaperCrop) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(text = "Crop", style = MaterialTheme.typography.titleSmall)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            WallpaperCrop.presets.forEach { crop ->
+                FilterChip(
+                    selected = adjustments.crop == crop,
+                    onClick = { if (enabled) onUpdateCrop(crop) },
+                    enabled = enabled,
+                    label = { Text(text = crop.displayName()) }
+                )
+            }
+            val currentSettings = when (val crop = adjustments.crop) {
+                is WallpaperCrop.Custom -> crop.settings
+                else -> adjustments.cropSettings ?: WallpaperCropSettings()
+            }
+            FilterChip(
+                selected = adjustments.crop is WallpaperCrop.Custom,
+                onClick = {
+                    if (enabled) onUpdateCrop(WallpaperCrop.Custom(currentSettings))
+                },
+                enabled = enabled,
+                label = { Text(text = "Custom") }
+            )
+        }
+
+        if (adjustments.crop is WallpaperCrop.Custom) {
+            CustomCropControls(
+                settings = adjustments.crop.settings,
+                enabled = enabled,
+                onUpdateCrop = onUpdateCrop
+            )
+        }
+    }
+}
+
+@Composable
+private fun CustomCropControls(
+    settings: WallpaperCropSettings,
+    enabled: Boolean,
+    onUpdateCrop: (WallpaperCrop) -> Unit,
+) {
+    var horizontal by remember(settings) {
+        mutableStateOf(settings.left..settings.right)
+    }
+    var vertical by remember(settings) {
+        mutableStateOf(settings.top..settings.bottom)
+    }
+
+    LaunchedEffect(settings) {
+        horizontal = settings.left..settings.right
+        vertical = settings.top..settings.bottom
+    }
+
+    fun applyCrop(
+        horizontalRange: ClosedFloatingPointRange<Float>,
+        verticalRange: ClosedFloatingPointRange<Float>
+    ) {
+        val sanitized = WallpaperCropSettings(
+            left = horizontalRange.start,
+            top = verticalRange.start,
+            right = horizontalRange.endInclusive,
+            bottom = verticalRange.endInclusive
+        ).sanitized()
+        val sanitizedHorizontal = sanitized.left..sanitized.right
+        val sanitizedVertical = sanitized.top..sanitized.bottom
+        if (horizontal == sanitizedHorizontal && vertical == sanitizedVertical) {
+            return
+        }
+        horizontal = sanitizedHorizontal
+        vertical = sanitizedVertical
+        onUpdateCrop(WallpaperCrop.Custom(sanitized))
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = "Adjust the crop window",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = "Horizontal", style = MaterialTheme.typography.labelLarge)
+            RangeSlider(
+                value = horizontal,
+                onValueChange = { range ->
+                    if (!enabled) return@RangeSlider
+                    applyCrop(range, vertical)
+                },
+                valueRange = 0f..1f,
+                steps = 0,
+                enabled = enabled
+            )
+            RangeLabel(range = horizontal)
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = "Vertical", style = MaterialTheme.typography.labelLarge)
+            RangeSlider(
+                value = vertical,
+                onValueChange = { range ->
+                    if (!enabled) return@RangeSlider
+                    applyCrop(horizontal, range)
+                },
+                valueRange = 0f..1f,
+                steps = 0,
+                enabled = enabled
+            )
+            RangeLabel(range = vertical)
+        }
+    }
+}
+
+@Composable
+private fun RangeLabel(range: ClosedFloatingPointRange<Float>) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = "Start: ${formatPercentage(range.start)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = "End: ${formatPercentage(range.endInclusive)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+private fun WallpaperFilter.displayName(): String = when (this) {
+    WallpaperFilter.NONE -> "None"
+    WallpaperFilter.GRAYSCALE -> "Grayscale"
+    WallpaperFilter.SEPIA -> "Sepia"
+}
+
+private fun formatPercentage(value: Float): String = "${(value * 100).roundToInt()}%"


### PR DESCRIPTION
## Summary
- update the filter and crop selectors to use FlowRow layouts and annotate for the experimental API
- disable the reset action until the editor is ready and reuse crop sanitization logic for both sliders
- avoid redundant crop updates by reusing a shared sanitizer before dispatching to the view model

## Testing
- :app:lint *(fails: Android SDK not present in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf285eb088330864381435d817043